### PR TITLE
Revert "Explicitly test the env var option with binary setting"

### DIFF
--- a/test/unit/test.utils.js
+++ b/test/unit/test.utils.js
@@ -61,16 +61,6 @@ describe("lib/utils", function () {
     expect(binary("/Application/FirefoxNightly.app", "darwin")).to.be.equal(
       "/Application/FirefoxNightly.app/Contents/MacOS/firefox-bin");
   });
-  
-  it("normalizeBinary() uses JPM_FIREFOX_BINARY if no path specified", function () {
-    process.env.JPM_FIREFOX_BINARY = "/my/custom/path";
-    expect(binary()).to.be.equal("/my/custom/path");
-  });
-  
-  it("normalizeBinary() uses path over JPM_FIREFOX_BINARY if specified", function () {
-    process.env.JPM_FIREFOX_BINARY = "/my/custom/path";
-    expect(binary("/specific/path")).to.be.equal("/specific/path");
-  });
 
   it("normalizeBinary() normalizes special names like: firefox, nightly, etc...", function() {
     var args = 0;


### PR DESCRIPTION
This reverts commit 088c57c8c534690313c67bbd5fc9bfa1a171cdcb.
