### PR TITLE
Load in temp files when using jpm init, fixes #58

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -1,0 +1,9 @@
+var self = require('sdk/self');
+
+// a dummy function, to show how tests work. 
+// to see how to test this function, look at ../test/test-main.js
+function dummy(text, callback) {
+  callback(text);
+}
+
+exports.dummy = dummy;

--- a/data/test-index.js
+++ b/data/test-index.js
@@ -1,0 +1,19 @@
+var main = require("./main");
+
+exports["test main"] = function(assert) {
+  assert.pass("Unit test running!");
+};
+
+exports["test main async"] = function(assert, done) {
+  assert.pass("async Unit test running!");
+  done();
+};
+
+exports["test dummy"] = function(assert, done) {
+  main.dummy("foo", function(text) {
+    asser.ok((text === "foo"), "Is the text actually 'foo'");
+    done();
+  });
+}
+
+require("sdk/test").run(exports);

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,15 +1,26 @@
 var promzard = require("promzard");
-var fs = require("fs");
+var fs = require("fs-promise");
 var read = require("read");
 var when = require("when");
-var path = require("path");
+var join = require("path").join;
 var initInput = require.resolve("./init-input");
 var console = require("./utils").console;
 
-function init (options) {
-  var deferred = when.defer();
+var SOURCE_INDEX = join(__dirname, "../data/index.js");
+var SOURCE_TEST = join(__dirname, "../data/test-index.js");
 
-  var packagePath = path.join(process.cwd(), "package.json");
+function init (options) {
+  var root = process.cwd();
+
+  return createManifest(root)
+    .then(createFiles.bind(null, root), console.error);
+}
+module.exports = init;
+
+function createManifest (root) {
+  var deferred = when.defer();
+  var packagePath = join(root, "package.json");
+
   promzard(initInput, {}, function (err, data) {
     if (err)
       deferred.reject(err);
@@ -21,16 +32,31 @@ function init (options) {
       default: "yes"
     }, function (err, ok) {
       if (!ok || ok.toLowerCase().charAt(0) !== "y") {
-        console.log("Aborted.");
+        deferred.reject("Aborted.");
       } else {
-        fs.writeFile(packagePath, data, "utf-8", function (err) {
-          if (err) deferred.reject(err);
-          else deferred.resolve();
-        });
+        fs.writeFile(packagePath, data, "utf-8").then(deferred.resolve, deferred.reject);
       }
     });
   });
-
   return deferred.promise;
 }
-module.exports = init;
+
+function createFiles (root) {
+  var indexPath = join(root, "index.js");
+  var testDirPath = join(root, "test");
+  var testPath = join(testDirPath, "test-index.js");
+
+  return fs.exists(indexPath).then(function (exists) {
+    if (!exists) {
+      return fs.copy(SOURCE_INDEX, indexPath);
+    }
+  }).then(function () {
+    return fs.mkdirp(testDirPath);
+  }).then(function (exists) {
+    return fs.exists(testPath).then(function (exists) {;
+      if (!exists) {
+        return fs.copy(SOURCE_TEST, testPath);
+      }
+    });
+  });
+}

--- a/test/functional/test.init.js
+++ b/test/functional/test.init.js
@@ -1,4 +1,4 @@
-var fs = require("fs");
+var fs = require("fs-extra");
 var path = require("path");
 var utils = require("../utils");
 var settings = require("../../lib/settings");
@@ -79,6 +79,56 @@ describe("jpm init", function () {
       done();
     });
   });
+  
+  it("copies in default index.js if it DNE", function (done) {
+    process.chdir(utils.tmpOutputDir);
+    var responses = generateResponses();
+    var proc = respond(exec("init"), responses);
+    proc.on("close", function () {
+      var dirIndex = fs.readFileSync(path.join(utils.tmpOutputDir, "index.js"), "utf-8");
+      var sourceIndex = fs.readFileSync(path.join("..", "..", "data", "index.js"), "utf-8");
+      expect(dirIndex).to.be.equal(sourceIndex);
+      done();
+    });
+  });
+  
+  it("does not copy in default index.js if it exists", function (done) {
+    process.chdir(utils.tmpOutputDir);
+    fs.writeFileSync(path.join(utils.tmpOutputDir, "index.js"), "hello");
+    var responses = generateResponses();
+    var proc = respond(exec("init"), responses);
+    proc.on("close", function () {
+      var dirIndex = fs.readFileSync(path.join(utils.tmpOutputDir, "index.js"), "utf-8");
+      expect(dirIndex).to.be.equal("hello");
+      done();
+    });
+  });
+  
+  it("copies in default test-index.js if it DNE", function (done) {
+    process.chdir(utils.tmpOutputDir);
+    var responses = generateResponses();
+    var proc = respond(exec("init"), responses);
+    proc.on("close", function () {
+      var dirTest = fs.readFileSync(path.join(utils.tmpOutputDir, "test", "test-index.js"), "utf-8");
+      var sourceTest = fs.readFileSync(path.join("..", "..", "data", "test-index.js"), "utf-8");
+      expect(dirTest).to.be.equal(sourceTest);
+      done();
+    });
+  });
+  
+  it("does not copy in default test-index.js if it exists", function (done) {
+    process.chdir(utils.tmpOutputDir);
+    fs.mkdirpSync(path.join(utils.tmpOutputDir, "test"));
+    fs.writeFileSync(path.join(utils.tmpOutputDir, "test", "test-index.js"), "hello");
+    var responses = generateResponses();
+    var proc = respond(exec("init"), responses);
+    proc.on("close", function () {
+      var dirTest = fs.readFileSync(path.join(utils.tmpOutputDir, "test", "test-index.js"), "utf-8");
+      expect(dirTest).to.be.equal("hello");
+      done();
+    });
+  });
+
 });
 
 /**


### PR DESCRIPTION
Scaffolds default `index.js` and `test/test-index.js` files when using `jpm init`. 
