### PR TITLE
Use firefox-profile module in npm rather than jsantell's fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "jetpack-id": "0.0.4",
-    "firefox-profile": "jsantell/firefox-profile-js",
+    "firefox-profile": "0.2.9",
     "commander": "2.1.0",
     "jsontoxml": "0.0.11",
     "fs-promise": "0.0.2",


### PR DESCRIPTION
Dependent on saadtazi/firefox-profile-js/pull/34 being merged and published
