### PR TITLE
added missing semi-colon ( causes jshint warning )

### DIFF
--- a/data/test-index.js
+++ b/data/test-index.js
@@ -14,6 +14,6 @@ exports["test dummy"] = function(assert, done) {
     assert.ok((text === "foo"), "Is the text actually 'foo'");
     done();
   });
-}
+};
 
 require("sdk/test").run(exports);


### PR DESCRIPTION
I noticed the third test lacks a trailing semi-colon so I added it. Man, I feel productive now.
