### PR TITLE
Firefox Process now streamable, updated error reporting

### DIFF
--- a/lib/firefox.js
+++ b/lib/firefox.js
@@ -1,4 +1,4 @@
-var exec = require("child_process").exec;
+var spawn = require("child_process").spawn;
 var defer = require("when").defer;
 var extend = require("underscore").extend;
 var createProfile = require("./profile");
@@ -6,6 +6,7 @@ var console = require("./utils").console;
 var normalizeBinary = require("./utils").normalizeBinary;
 var getID = require("jetpack-id");
 var TEST_RESULTS_REGEX = /\d+ of \d+ tests passed/i
+var isTest = process.env.NODE_ENV === "test";
 
 /**
  * Takes a manifest object (from package.json) and options,
@@ -25,7 +26,7 @@ function runFirefox (manifest, options) {
   var runDeferred = defer();
   options = options || {};
   var binary = null;
-  var args = ['-no-remote'];
+  var args = ["-no-remote"];
 
   // Create profile if none passed in
   if (!options.profile) {
@@ -39,14 +40,12 @@ function runFirefox (manifest, options) {
     // Firefox takes -P if given a profile name and
     // -profile if given a path (starting with "/" or "./").
     if (!/[\\\/]/.test(profile))
-      args = args.concat(['-P', profile]);
+      args = args.concat(["-P", profile]);
     else
-      args = args.concat(['-profile', '"' + profile + '"']);
+      args = args.concat(["-profile", profile]);
 
     if (options.binaryArgs)
       args = args.concat(options.binaryArgs.split(" "));
-
-    var cmd = '"' + binary + '" ' + args.join(" ");
 
     if (options.verbose)  {
       console.log("Executing Firefox binary: " + binary);
@@ -59,49 +58,68 @@ function runFirefox (manifest, options) {
     });
 
     // Use `process.std[out|err].write` to write to screen
-    // instead of console.log since console.logs are silenced during testing
-    var task = exec(cmd, { env: env }, function(err, stdout, stderr) {
+    // instead of console.log during testing with the helpers below.
+    //
+    // Using `spawn` so we can stream logging as they come in, rather than buffer them up
+    // until the end, which can easily hit the max buffer size.
+    var firefox = spawn(binary, args, { env: env });
+
+    firefox.on("error", function (err) {
       if (/No such file/.test(err)) {
         console.error("No Firefox binary found at " + binary);
         if (!options.binary) {
           console.error("Specify a Firefox binary to use with the `-b` flag.");
         }
+      } else {
+        console.error(err);
       }
-
-      process.removeListener("exit", killFirefox);
-
-      if (options.verbose) {
-        if (err) {
-          process.stdout.write("err: " + err + '\n');
-        }
-        process.stderr.write(stderr);
-      }
-
-      runDeferred.resolve(task);
+      runDeferred.reject(firefox);
     });
 
-    task.stdout.on("data", function(data) {
+    firefox.on("close", function () {
+      process.removeListener("exit", killFirefox);
+      runDeferred.resolve(firefox);
+    });
+
+    firefox.stderr.on("data", function (data) {
+      // Only print out annoying warnings if verbose is on
+      if (/^\s*System JS : WARNING/.test(data) && options.verbose) {
+        writeWarn(data);
+      }
+      // Otherwise if verbose is on, and we find something, probably a serious error.
+      else if (options.verbose) {
+        writeError(data);
+      }
+    });
+
+    // Many errors in addons are printed to stdout instead of stderr;
+    // we should check for errors here and print them out regardless of
+    // verbose status
+    firefox.stdout.on("data", function (data) {
       var write = false;
 
-      if (options.verbose ||
-          TEST_RESULTS_REGEX.test(data) ||
-          logFromAddon(manifest, data)) {
+      if (options.verbose ||                    // Print everything in verbose
+          TEST_RESULTS_REGEX.test(data) ||      // Print test results always
+          logFromAddon(manifest, data)) {       // Print any logs from addon always
         write = true;
       }
 
-      if (write) {
-        process.stdout.write(data);
+      if (isErrorString(data)) {
+        writeError(data);
+      } else if (write) {
+        writeLog(data);
       }
     });
 
     function killFirefox () {
-      task.kill();
+      firefox.kill();
     }
 
     // Kill child process when main process is killed
     process.once("exit", killFirefox);
     return runDeferred.promise;
   }
+
   return normalizeBinary(options.binary).then(function(path) {
     binary = path;
     return profileDeferred.promise;
@@ -112,5 +130,24 @@ module.exports = runFirefox;
 function logFromAddon (manifest, line) {
   // Use `manifest.name` instead of ID, since that's what the SDK uses to log
   return (new RegExp("^console\\.[a-z]+: " + manifest.name + ":")).test(line);
+}
 
+function isErrorString (line) {
+  if (/^\*{25}/.test(line))
+    return true;
+  if (/^\s*Message: [\D]*Error/.test(line))
+    return true;
+  return false;
+}
+
+function writeError (s) {
+  isTest ? process.stderr.write(s) : console.error(s);
+}
+
+function writeLog (s) {
+  isTest ? process.stdout.write(s) : console.log(s);
+}
+
+function writeWarn (s) {
+  isTest ? process.stdout.write(s) : console.warn(s);
 }

--- a/test/addons/error-addon/index.js
+++ b/test/addons/error-addon/index.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const { Cc, Ci } = require("chrome");
+const { quit, eForceQuit } = Cc['@mozilla.org/toolkit/app-startup;1'].
+                             getService(Ci.nsIAppStartup);
+const { setTimeout } = require("sdk/timers");
+const exit = () => quit(eForceQuit);
+
+setTimeout(exit, 1);
+
+sadf

--- a/test/addons/error-addon/package.json
+++ b/test/addons/error-addon/package.json
@@ -1,0 +1,7 @@
+{
+  "title": "Error Addon",
+  "name": "error-addon",
+  "engines": {
+    "Firefox": ">=24"
+  }
+}

--- a/test/functional/test.run.js
+++ b/test/functional/test.run.js
@@ -8,6 +8,7 @@ var isWindows = /^win/.test(process.platform);
 
 var addonsPath = path.join(__dirname, "..", "addons");
 var simpleAddonPath = path.join(addonsPath, "simple-addon");
+var errorAddonPath = path.join(addonsPath, "error-addon");
 var paramDumpPath = path.join(addonsPath, "param-dump");
 var loaderOptionsPath = path.join(addonsPath, "loader-options");
 var overloadablePath = path.join(addonsPath, "overloadable");
@@ -109,6 +110,16 @@ describe("jpm run", function () {
       var proc = exec("run -v", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout.split("\n").length).to.be.gt(20);
+        done();
+      });
+    });
+  
+    it("logs errors without `verbose`", function (done) {
+      process.chdir(errorAddonPath);
+      var options = { cwd: errorAddonPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var proc = exec("run", options, function (err, stdout, stderr) {
+        expect(err).to.not.be.ok;
+        expect(stderr).to.contain("ReferenceError");
         done();
       });
     });


### PR DESCRIPTION
Fixes #130, #133, #92.

Moves Firefox process to a `spawn` which streams output as it comes in -- in doing this, cleaned up a lot of discrepencies in logging -- now, errors are always shown as errors (regardless of verbose), just like console logging, and verbose prints out everything as it did before, so this adds some better filters.
