### PR TITLE
Allow semver versions during jpm init

### DIFF
--- a/lib/init-input.js
+++ b/lib/init-input.js
@@ -1,5 +1,6 @@
 var path = require("path");
 var MIN_VERSION = require("./settings").MIN_VERSION;
+var semver = require("semver");
 
 module.exports = {
   "title": prompt("title", "My Jetpack Addon", identity),
@@ -45,10 +46,8 @@ function sanitizeName (name) {
  * @return {String}
  */
 
-function sanitizeVersion (ver) {
-  if (/^\d+\.\d+\.\d+$/.test(ver))
-    return ver;
-  return "0.0.0";
+function sanitizeVersion (version) {
+  return semver.valid(version) || "0.0.0";
 }
 
 /**

--- a/test/functional/test.init.js
+++ b/test/functional/test.init.js
@@ -130,6 +130,18 @@ describe("jpm init", function () {
     });
   });
 
+  it("allows non-numeric version strings", function (done) {
+    process.chdir(utils.tmpOutputDir);
+    var responses = ["", "", "v0.4.0-rc4", "", "", "", "", "", "yes"];
+
+    var proc = respond(exec("init"), responses.map(function (val) {
+      return val + '\n';
+    }));
+    proc.on("close", function () {
+      var manifest = JSON.parse(fs.readFileSync(path.join(utils.tmpOutputDir, "package.json"), "utf-8"));
+      expect(manifest.version).to.be.equal("0.4.0-rc4")
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
Previously, this would fail if supplying `jpm init` with a version containing valid semver versions (like `0.4.0-rc4`)
