### PR TITLE
Support wildcard engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "read": "1.0.5",
     "semver": "2.2.1",
     "mozilla-version-comparator": "1.0.2",
-    "mozilla-toolkit-versioning": "0.0.1",
+    "mozilla-toolkit-versioning": "0.0.2",
     "jetpack-validation": "0.0.4",
     "winreg": "0.0.12",
     "xml-escape": "1.0.0"

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -174,7 +174,19 @@ describe("lib/rdf", function () {
       expect(fennec.childNodes[5].childNodes[0].data).to.be.equal("*");
     });
 
-    it("replaces undefined min versions with asterisks", function () {
+    it("handles wildcard versions with MIN_VERSION - *", function () {
+      var xml = setupRDF({ engines: {
+        firefox: "*"
+      }});
+      var apps = xml.getElementsByTagName("em:targetApplication");
+      var fennec = apps[0].childNodes[1]; // Description
+      expect(fennec.childNodes[3].tagName).to.be.equal("em:minVersion");
+      expect(fennec.childNodes[3].childNodes[0].data).to.be.equal(MIN_VERSION);
+      expect(fennec.childNodes[5].tagName).to.be.equal("em:maxVersion");
+      expect(fennec.childNodes[5].childNodes[0].data).to.be.equal("*");
+    });
+
+    it("replaces undefined min versions with MIN_VERSION", function () {
       var xml = setupRDF({ engines: {
         fennec: "<30.0"
       }});


### PR DESCRIPTION
By default, jpm will create an engine range from 33.0a1 to \* (rdf's require a min version, and this is min version that jpm supports anyway) -- if you specify a "*" engine (common in node), it should support the same as everything possible (so MIN_VERSION - whatever)
