### PR TITLE
we should create a default .jpmignore file when jpm init is run.

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -10,6 +10,8 @@ var when = require("when");
 var join = require("path").join;
 var initInput = require.resolve("./init-input");
 var console = require("./utils").console;
+var getID = require("jetpack-id");
+var getManifest = require("./utils").getManifest;
 
 var SOURCE_INDEX = join(__dirname, "../data/index.js");
 var SOURCE_README = join(__dirname, "../data/README.md");
@@ -55,6 +57,7 @@ function createFiles (root) {
   var readmePath = join(root, "README.md");
   var testDirPath = join(root, "test");
   var testPath = join(testDirPath, "test-index.js");
+  var ignorePath = join(root, ".jpmignore");
 
   return fs.exists(indexPath).then(function (exists) {
     return (exists) ? null : fs.copy(SOURCE_INDEX, indexPath);
@@ -73,5 +76,13 @@ function createFiles (root) {
   })
   .then(function (exists) {
     return (exists) ? null : fs.copy(SOURCE_TEST, testPath);
+  })
+  .then(function() {
+    return getManifest();
+  })
+  .then(function (manifest) {
+    // create .jpmignore, with the name of the generated xpi file by default
+    var XPI_FILE = getID(manifest) + ".xpi";
+    return fs.writeFile(ignorePath, XPI_FILE);
   });
 }

--- a/test/functional/test.init.js
+++ b/test/functional/test.init.js
@@ -171,6 +171,22 @@ describe("jpm init", function () {
       done();
     });
   });
+
+  it("creates a .jpmignore file", function (done) {
+    process.chdir(utils.tmpOutputDir);
+    var responses = ["", "", "v0.4.0-rc4", "", "", "", "", "", "yes"];
+
+    var proc = respond(exec("init"), responses.map(function (val) {
+      return val + '\n';
+    }));
+    proc.on("close", function () {
+      var ignorePath = path.join(utils.tmpOutputDir, ".jpmignore");
+      expect(fs.existsSync(ignorePath)).to.be.equal(true);
+      var ignore = fs.readFileSync(ignorePath, "utf-8");
+      expect(ignore).to.be.equal("@tmp.xpi");
+      done();
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
This specifically prevents users from running into the problem created in issue #226 by default, and hopefully educates users about the existence of .jpmignore.
