### PR TITLE
Dedupe "xpi created" messages

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -68,9 +68,10 @@ program
     var start = Date.now();
     xpi(manifest, program).then(function(xpiPath) {
       var diff = Date.now() - start;
-      console.log("Successfully created xpi at " + xpiPath + " (" + diff + "ms)");
+      console.log("Successfully created XPI at " +
+                  xpiPath + " (" + diff + "ms)");
     }, function(reason) {
-      console.error("xpi creation failed: " + reason);
+      console.error("XPI creation failed: " + reason);
     });
   }));
 

--- a/bin/jpm
+++ b/bin/jpm
@@ -65,8 +65,10 @@ program
   .command("xpi")
   .description("Bundle the addon into an .xpi file")
   .action(cmd.prepare("xpi", program, function(manifest) {
+    var start = Date.now();
     xpi(manifest, program).then(function(xpiPath) {
-      console.log("Successfully created xpi at " + xpiPath);
+      var diff = Date.now() - start;
+      console.log("Successfully created xpi at " + xpiPath + " (" + diff + "ms)");
     }, function(reason) {
       console.error("xpi creation failed: " + reason);
     });

--- a/lib/xpi.js
+++ b/lib/xpi.js
@@ -8,6 +8,7 @@ var getID = require("jetpack-id");
 var validate = require("./validate");
 var hasAOMSupport = require("./utils").hasAOMSupport;
 var utils = require("./xpi/utils");
+var console = require("./utils").console;
 var _ = require("lodash");
 
 /**
@@ -59,14 +60,18 @@ function xpi(manifest, options) {
     })
     .then(function(fallbacks) {
       options.fallbacks = fallbacks;
-      console.log("Creating XPI");
+      if (options.verbose){
+        console.log("Creating XPI");
+      }
       return utils.createZip(options);
     })
     .then(function() {
       return utils.createUpdateRDF(options, updateRdfPath);
     })
     .then(function() {
-      console.log("Created XPI at " + xpiPath);
+      if (options.verbose){
+        console.log("Created XPI at " + xpiPath);
+      }
       return xpiPath;
     });
 }

--- a/lib/xpi.js
+++ b/lib/xpi.js
@@ -60,7 +60,7 @@ function xpi(manifest, options) {
     })
     .then(function(fallbacks) {
       options.fallbacks = fallbacks;
-      if (options.verbose){
+      if (options.verbose) {
         console.log("Creating XPI");
       }
       return utils.createZip(options);
@@ -69,7 +69,7 @@ function xpi(manifest, options) {
       return utils.createUpdateRDF(options, updateRdfPath);
     })
     .then(function() {
-      if (options.verbose){
+      if (options.verbose) {
         console.log("Created XPI at " + xpiPath);
       }
       return xpiPath;

--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -98,11 +98,10 @@ function createFallbacks(options) {
 exports.createFallbacks = createFallbacks;
 
 function createZip(options) {
-  var start = Date.now();
   var dir = options.addonDir;
 
   if (options.verbose) {
-    console.log("Creating XPI...");
+    console.log("Zipping up files...");
   }
 
   return zip(options, dir, options.xpiPath).then(function(result) {
@@ -136,10 +135,6 @@ function createZip(options) {
         return result;
       });
     });
-  }).then(function(result) {
-    var diff = Date.now() - start;
-    console.log("XPI created at " + options.xpiPath + " (" + diff + "ms)");
-    return result;
   });
 }
 exports.createZip = createZip;

--- a/test/functional/test.run.js
+++ b/test/functional/test.run.js
@@ -125,17 +125,7 @@ describe("jpm run", function() {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("console\.log: param-dump:");
         expect(stdout).to.contain("PARAMS DUMP START");
-        done();
-      });
-    });
-
-    it("logs out everything from console with -v", function(done) {
-      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
-      var proc = exec("run -v", options, function(err, stdout, stderr) {
-        expect(err).to.not.be.ok;
-        expect(stdout.split("\n").length).to.be.gt(2);
-        expect(stdout).to.contain("PARAMS DUMP START");
-        expect(stdout).to.contain("PARAMS DUMP END");
+        expect(stderr).not.to.contain("JavaScript error");
         done();
       });
     });


### PR DESCRIPTION
Before:
![screenshot 2015-02-22 10 50 09](https://cloud.githubusercontent.com/assets/2622601/6318137/994b997e-ba80-11e4-9c92-98854e7e4d65.png)

After:
![screenshot 2015-02-22 10 47 27](https://cloud.githubusercontent.com/assets/2622601/6318132/408d86e4-ba80-11e4-9499-eeba85dd13f3.png)

If you want to show the xpi location in `jpm test` or `jpm run`, you can use the -v flag.
