### PR TITLE
Tweaks jpm to turn it into a nodejs library

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -25,6 +25,7 @@ program
   .option("-o, --overload [path]", "Overloads the built-in Firefox SDK modules with a local copy located at environment variable `JETPACK_ROOT` or `path` if supplied. Used for development on the SDK itself.")
   .option("-f, --filter <pattern>", "--filter=FILENAME[:TESTNAME] only run tests whose filenames match FILENAME and " +
                       "optionally match TESTNAME, both regexps")
+  .option("--addon-dir <path>", "Path of Firefox addon to build.", process.cwd())
   .option("--binary-args <CMDARGS>", "Pass additional arguments into Firefox.")
   .option("--prefs <path>", "Custom set user preferences (path to a json file)")
   .option("--post-url <url>", "A url to post a xpi of your extension")
@@ -117,4 +118,3 @@ program.parse(process.argv);
 if (cmd.isEmptyCommand(program)) {
   program.help();
 }
-

--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -11,7 +11,7 @@ var DEBUG_VALUES = ["binary", "verbose", "binaryArgs", "overload", "profile"];
 
 function prepare (mode, program, actionCallback) {
   return function () {
-    return utils.getManifest().then(function(manifest) {
+    return utils.getManifest(program.addonDir).then(function(manifest) {
       var args = Array.prototype.slice.call(arguments, 0);
       Object.keys(program).filter(function (option) {
         return ~DEBUG_VALUES.indexOf(option);

--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -23,7 +23,7 @@ var getID = require("jetpack-id");
 function ignore (dir, options) {
   var jpmignore = path.join(dir, ".jpmignore");
   var default_rules = ["*.zip", ".*", "test/", ".jpmignore"];
-  return getManifest()
+  return getManifest(options.addonDir)
   .then(function(manifest) {
     // add the xpi file name to the ignore list
     var xpiName = getID(manifest) + "*.xpi";

--- a/lib/task.js
+++ b/lib/task.js
@@ -28,7 +28,7 @@ function removeXPI(options) {
 }
 
 function execute(manifest, options) {
-  options = options || {};
+  options = options || { addonDir: process.cwd() };
   var id = getID(manifest);
 
   if (~["run", "test"].indexOf(options.command)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,16 +88,15 @@ exports.console = Object.freeze(jpmConsole);
  *
  * @return {Object}
  */
-function getManifest () {
+function getManifest (addonDir) {
   return when.promise(function(resolve, reject) {
-    var cwd = process.cwd();
-    var json = path.join(cwd, "package.json");
+    var json = path.join(addonDir, "package.json");
     var manifest = {};
     try {
       manifest = require(json);
     }
     catch (e) {}
     return resolve(manifest);
-  })
+  });
 }
 exports.getManifest = getManifest;

--- a/lib/xpi.js
+++ b/lib/xpi.js
@@ -26,10 +26,10 @@ var _ = require("lodash");
 
 function xpi (manifest, options) {
   options = options || {};
+  options.addonDir = options.addonDir || process.cwd();
   var xpiVersion = manifest.version ? ("-" + manifest.version) : "";
   var xpiName = getID(manifest) + xpiVersion + ".xpi";
-  var dir = process.cwd();
-  var xpiPath = join(options.xpiPath || dir, xpiName);
+  var xpiPath = join(options.xpiPath || options.addonDir, xpiName);
   var useFallbacks = !(options.forceAOM || hasAOMSupport(manifest));
 
   options = _.merge(options, {
@@ -47,7 +47,7 @@ function xpi (manifest, options) {
         if (options.verbose) {
           console.log("Validating the manifest")
         }
-        return validate(dir);
+        return validate(options.addonDir);
       }
       return null;
     })

--- a/lib/xpi.js
+++ b/lib/xpi.js
@@ -54,9 +54,12 @@ function xpi (manifest, options) {
     .then(function() {
       return utils.createFallbacks(options);
     })
-    .then(function() {
+    .then(function(fallbacks) {
       console.log("Creating XPI");
-      return utils.createZip(options);
+      return utils.createZip(options, {
+        installRDF: fallbacks[0],
+        bootstrapJS: fallbacks[1]
+      });
     })
     .then(function() {
       return utils.removeFallbacks(options);

--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -23,9 +23,8 @@ function getData (xml, tag) {
 exports.getData = getData;
 
 function checkNeedsFallbacks(options) {
-  var dir = process.cwd();
-  var rdfPath = join(dir, "install.rdf");
-  var bsPath = join(dir, "bootstrap.js");
+  var rdfPath = join(options.addonDir, "install.rdf");
+  var bsPath = join(options.addonDir, "bootstrap.js");
 
   if (!options.useFallbacks) {
     options.needsInstallRDF = false;
@@ -66,28 +65,26 @@ exports.checkNeedsFallbacks = checkNeedsFallbacks;
 // Creates bootstrap.js/install.rdf -- will be removed once
 // AOM is updated
 function createFallbacks (options) {
-  var dir = process.cwd();
-  var rdfPath = join(dir, "install.rdf");
-  var bsPath = join(dir, "bootstrap.js");
+  var rdfPath = join(options.addonDir, "install.rdf");
+  var bsPath = join(options.addonDir, "bootstrap.js");
   var bootstrapSrc = options.bootstrapSrc;
 
   if (options.useFallbacks && options.verbose) {
     console.log("Creating fallbacks if they are necessary..");
   }
 
-  return getManifest().then(function(manifest) {
+  return getManifest(options.addonDir).then(function(manifest) {
     return when.all([
       options.needsInstallRDF ? fs.writeFile(rdfPath, createRDF(manifest)) : when.resolve(),
       options.needsBootstrapJS ? fs.copy(bootstrapSrc, bsPath) : when.resolve(),
-    ])
+    ]);
   });
 }
 exports.createFallbacks = createFallbacks;
 
 function removeFallbacks (options) {
-  var dir = process.cwd();
-  var rdfPath = join(dir, "install.rdf");
-  var bsPath = join(dir, "bootstrap.js");
+  var rdfPath = join(options.addonDir, "install.rdf");
+  var bsPath = join(options.addonDir, "bootstrap.js");
 
   if (options.useFallbacks && options.verbose) {
     console.log("Removing fallbacks if they were necessary..");
@@ -102,7 +99,7 @@ exports.removeFallbacks = removeFallbacks;
 
 function createZip (options) {
   var start = Date.now();
-  var dir = process.cwd();
+  var dir = options.addonDir;
 
   if (options.verbose) {
     console.log("Creating XPI...");

--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -75,8 +75,8 @@ function createFallbacks (options) {
 
   return getManifest(options.addonDir).then(function(manifest) {
     return when.all([
-      options.needsInstallRDF ? fs.writeFile(rdfPath, createRDF(manifest)) : when.resolve(),
-      options.needsBootstrapJS ? fs.copy(bootstrapSrc, bsPath) : when.resolve(),
+      options.needsInstallRDF ? when.resolve(createRDF(manifest)) : when.resolve(),
+      options.needsBootstrapJS ? when.resolve(fs.readFile(bootstrapSrc)) : when.resolve(),
     ]);
   });
 }
@@ -97,7 +97,9 @@ function removeFallbacks (options) {
 }
 exports.removeFallbacks = removeFallbacks;
 
-function createZip (options) {
+var Zip = require('zip-dir/node_modules/jszip');
+
+function createZip (options, fallbacks) {
   var start = Date.now();
   var dir = options.addonDir;
 
@@ -107,8 +109,31 @@ function createZip (options) {
 
   return zip(options, dir, options.xpiPath).then(function (result) {
     var diff = Date.now() - start;
-    console.log("XPI created at " + options.xpiPath + " (" + diff + "ms)");
-    return result;
+
+    return fs.readFile(options.xpiPath).then(function (data) {
+      if (!fallbacks || (!fallbacks.installRDF && !fallbacks.bootstrapJS)) {
+        // return the zip file if there isn't any needed fallback file
+        return result;
+      }
+
+      // add the needed fallbacks files into the zip file
+      var zip = new Zip(data);
+
+      if (fallbacks.installRDF) {
+        zip.file("install.rdf", fallbacks.installRDF);
+      }
+
+      if (fallbacks.bootstrapJS) {
+        zip.file("bootstrap.js", fallbacks.bootstrapJS);
+      }
+
+      var buffer = zip.generate({type:"nodebuffer"});
+
+      return fs.writeFile(result, buffer).then(function () {
+        console.log("XPI created at " + options.xpiPath + " (" + diff + "ms)");
+        return result;
+      });
+    });
   });
 }
 exports.createZip = createZip;

--- a/test/addon_runners/test.addon_runners.js
+++ b/test/addon_runners/test.addon_runners.js
@@ -25,7 +25,7 @@ describe("jpm run addons", function () {
       var addonPath = path.join(addonsPath, file);
       process.chdir(addonPath);
 
-      var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
       if (process.env.DISPLAY) {
         options.env.DISPLAY = process.env.DISPLAY;
       }

--- a/test/addons/test.addons.js
+++ b/test/addons/test.addons.js
@@ -23,9 +23,8 @@ describe("jpm test addons", function () {
   .forEach(function (file) {
     it(file, function (done) {
       var addonPath = path.join(addonsPath, file);
-      process.chdir(addonPath);
 
-      var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
       if (process.env.DISPLAY) {
         options.env.DISPLAY = process.env.DISPLAY;
       }

--- a/test/functional/test.run.js
+++ b/test/functional/test.run.js
@@ -40,7 +40,6 @@ describe("jpm run", function () {
 
   it("should not overwrite or delete xpi in current xpi", function (done) {
     var size = null;
-    process.chdir(paramDumpPath);
     // Copy over a different xpi and rename it to the would-be generated xpi name
     fs.copy(path.join(__dirname, "..", "xpis", "@aom-unsupported.xpi"), path.join(paramDumpPath, "@param-dump.xpi")).then(function () {
       return fs.stat(path.join(paramDumpPath, "@param-dump.xpi"));
@@ -48,7 +47,7 @@ describe("jpm run", function () {
       size = stat.size;
       expect(size).to.be.greaterThan(0);
 
-      var options = { cwd: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         fs.stat(path.join(paramDumpPath, "@param-dump.xpi")).then(function (stat) {
@@ -75,7 +74,7 @@ describe("jpm run", function () {
 
     it("does not overload if overload set and JETPACK_ROOT is not set", function (done) {
       process.env.JETPACK_ROOT = "";
-      var options = { cwd: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -o -v", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.not.contain("OVERLOADED STARTUP");
@@ -86,7 +85,7 @@ describe("jpm run", function () {
 
     it("overloads the SDK if overload set and JETPACK_ROOT set", function (done) {
       process.env.JETPACK_ROOT = path.join(__dirname, "../fixtures/mock-sdk");
-      var options = { cwd: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -o -v", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("OVERLOADED STARTUP");
@@ -97,7 +96,7 @@ describe("jpm run", function () {
     it("overloads the SDK with [path] if set over JETPACK_ROOT", function (done) {
       process.env.JETPACK_ROOT = "/an/invalid/path";
       var sdkPath = path.join(__dirname, "../fixtures/mock-sdk");
-      var options = { cwd: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -v -o " + sdkPath, options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("OVERLOADED STARTUP");
@@ -108,7 +107,7 @@ describe("jpm run", function () {
     it("overloads the SDK if overload set and uses [path] if given", function (done) {
       process.env.JETPACK_ROOT = "";
       var sdkPath = path.join(__dirname, "../fixtures/mock-sdk");
-      var options = { cwd: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -v -o " + sdkPath, options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("OVERLOADED STARTUP");
@@ -120,8 +119,7 @@ describe("jpm run", function () {
 
   describe("-v/--verbose", function () {
     it("logs out only console messages from the addon without -v", function (done) {
-      process.chdir(paramDumpPath);
-      var options = { cwd: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("console\.log: param-dump:")
@@ -131,8 +129,7 @@ describe("jpm run", function () {
     });
 
     it("logs out everything from console with -v", function (done) {
-      process.chdir(paramDumpPath);
-      var options = { cwd: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -v", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout.split("\n").length).to.be.gt(2);
@@ -143,8 +140,7 @@ describe("jpm run", function () {
     });
 
     it("logs errors without `verbose`", function (done) {
-      process.chdir(errorAddonPath);
-      var options = { cwd: errorAddonPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: errorAddonPath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stderr).to.contain("ReferenceError");
@@ -155,8 +151,7 @@ describe("jpm run", function () {
 
   describe("-b/--binary <BINARY>", function () {
     it("Uses specified binary instead of default Firefox", function (done) {
-      process.chdir(simpleAddonPath);
-      var proc = exec("run -b " + fakeBinary, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -b " + fakeBinary, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-foreground -no-remote -profile");
         done();
@@ -166,8 +161,7 @@ describe("jpm run", function () {
 
   describe("--binary-args <CMDARGS>", function () {
     it("Passes in additional arguments to Firefox (single)", function (done) {
-      process.chdir(simpleAddonPath);
-      var proc = exec("run -v -b " + fakeBinary + " --binary-args -some-value", { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " --binary-args -some-value", { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-some-value");
         done();
@@ -175,8 +169,7 @@ describe("jpm run", function () {
     });
 
     it("Passes in additional arguments to Firefox (multiple)", function (done) {
-      process.chdir(simpleAddonPath);
-      var proc = exec("run -v -b " + fakeBinary + " --binary-args \"-one -two -three\"", { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " --binary-args \"-one -two -three\"", { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-one -two -three");
         done();
@@ -186,8 +179,7 @@ describe("jpm run", function () {
 
   describe("-p/--profile", function () {
     it("Passes in a new temporary profile path to Firefox when -profile is not set", function (done) {
-      process.chdir(simpleAddonPath);
-      var proc = exec("run -v -b " + fakeBinary, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-profile ");
         expect(stdout).to.not.contain("-no-copy");
@@ -196,9 +188,8 @@ describe("jpm run", function () {
     });
 
     it("Passes in a temporary profile path instead of the original", function (done) {
-      process.chdir(simpleAddonPath);
       var tempProfile = new FirefoxProfile();
-      var proc = exec("run -v -b " + fakeBinary + " -p " + tempProfile.profileDir, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " -p " + tempProfile.profileDir, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-profile ");
         expect(stdout).to.not.contain("-profile " + tempProfile.profileDir);
@@ -208,9 +199,8 @@ describe("jpm run", function () {
     });
 
     it("Does not pass in a temporary profile path instead of the original with --no-copy", function (done) {
-      process.chdir(simpleAddonPath);
       var tempProfile = new FirefoxProfile();
-      var proc = exec("run -v -b " + fakeBinary + " --no-copy -p " + tempProfile.profileDir, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " --no-copy -p " + tempProfile.profileDir, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-profile ");
         expect(stdout).to.contain("-profile " + tempProfile.profileDir);
@@ -220,9 +210,8 @@ describe("jpm run", function () {
     });
 
     it("--no-copy alone passes in a temporary profile path instead of the original", function (done) {
-      process.chdir(simpleAddonPath);
       var tempProfile = new FirefoxProfile();
-      var proc = exec("run -v -b " + fakeBinary + " --no-copy -p " + tempProfile.profileDir, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " --no-copy -p " + tempProfile.profileDir, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-profile " + tempProfile.profileDir);
         expect(stdout).to.not.contain("-no-copy");
@@ -231,7 +220,6 @@ describe("jpm run", function () {
     });
 
     it("Passes in a profile name results in -p <path>", function (done) {
-      process.chdir(simpleAddonPath);
       var binary = process.env.JPM_FIREFOX_BINARY || "nightly";
 
       // find firefox nightly
@@ -256,7 +244,7 @@ describe("jpm run", function () {
           then(function(profilePath) {
             var cmd = "run -v -b " + fakeBinary + " -p jpm-test";
             // jpm run -b fakeBinary -p jpm-test
-            var proc = exec(cmd, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+            var proc = exec(cmd, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
               expect(err).to.not.be.ok;
               expect(stdout).to.not.contain("-P jpm-test");
               expect(stdout).to.not.contain("-profile " + profilePath);
@@ -269,7 +257,7 @@ describe("jpm run", function () {
     });
 
     describe("options passed to an add-on", function() {
-      var options = { cwd: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary } }
+      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary } }
 
       function readParams(stdout) {
         var output = stdout.toString()
@@ -288,7 +276,6 @@ describe("jpm run", function () {
       }
 
       it("run with only -v option", function(done) {
-        process.chdir(paramDumpPath);
         var task = exec("run -v", options, function(error, stdout, stderr) {
           expect(error).to.not.be.ok;
           //expect(stderr).to.not.be.ok;
@@ -375,8 +362,7 @@ describe("jpm run", function () {
 
   describe("SDK context", function () {
     it("@loader/options#metadata loads in package.json", function (done) {
-      process.chdir(loaderOptionsPath);
-      var options = { cwd: loaderOptionsPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: loaderOptionsPath, env: { JPM_FIREFOX_BINARY: binary }};
       var task = exec("run -v", options, function(error, stdout, stderr) {
         expect(error).to.not.be.ok;
 

--- a/test/functional/test.test.js
+++ b/test/functional/test.test.js
@@ -20,9 +20,8 @@ describe("jpm test", function () {
 
   it("test-success", function (done) {
     var addonPath = path.join(addonsPath, "test-success");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test", options, function (err, stdout, stderr) {
       expect(stdout).to.contain("2 of 2 tests passed.");
       expect(stdout).to.contain("All tests passed!");
@@ -35,9 +34,8 @@ describe("jpm test", function () {
 
   it("test-success with verbose", function (done) {
     var addonPath = path.join(addonsPath, "test-success");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test -v", options, function (err, stdout, stderr) {
       expect(stdout).to.contain("2 of 2 tests passed.");
       expect(stdout).to.contain("All tests passed!");
@@ -50,9 +48,8 @@ describe("jpm test", function () {
 
   it("test-failure", function (done) {
     var addonPath = path.join(addonsPath, "test-failure");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test", options, function (err, stdout, stderr) {
       expect(stdout).to.contain("1 of 2 tests passed.");
       expect(stdout).to.not.contain("All tests passed!");
@@ -67,9 +64,8 @@ describe("jpm test", function () {
 
   it("test-failure with verbose", function (done) {
     var addonPath = path.join(addonsPath, "test-failure");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test -v", options, function (err, stdout, stderr) {
       expect(stdout).to.contain("1 of 2 tests passed.");
       expect(stdout).to.not.contain("All tests passed!");
@@ -85,9 +81,8 @@ describe("jpm test", function () {
 
   it("test-logging-german-char", function (done) {
     var addonPath = path.join(addonsPath, "test-logging-german-char");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test -v", options, function (err, stdout, stderr) {
       expect(stdout).to.contain("1 of 1 tests passed.");
       expect(stdout).to.contain("All tests passed!");

--- a/test/functional/test.xpi.js
+++ b/test/functional/test.xpi.js
@@ -17,8 +17,7 @@ describe("jpm xpi", function () {
   afterEach(utils.tearDown);
 
   it("creates a xpi of the cwd", function (done) {
-    process.chdir(simpleAddonPath);
-    var proc = exec("xpi", { cwd: simpleAddonPath });
+    var proc = exec("xpi", { addonDir: simpleAddonPath });
     proc.on("close", function () {
       var xpiPath = path.join(simpleAddonPath, "@simple-addon-1.0.0.xpi");
 

--- a/test/unit/test.utils.js
+++ b/test/unit/test.utils.js
@@ -19,17 +19,14 @@ describe("lib/utils", function () {
   beforeEach(function () {
     if (process.env.JPM_FIREFOX_BINARY)
       prevBinary = process.env.JPM_FIREFOX_BINARY;
-    prevDir = process.cwd();
   });
   afterEach(function () {
     if (prevBinary)
       process.env.JPM_FIREFOX_BINARY = prevBinary;
-    process.chdir(prevDir);
   });
 
   it("getManifest() returns manifest in cwd()", function (done) {
-    process.chdir(simpleAddonPath);
-    utils.getManifest().then(function(manifest) {
+    utils.getManifest(simpleAddonPath).then(function(manifest) {
       expect(manifest.name).to.be.equal("simple-addon");
       expect(manifest.title).to.be.equal("My Simple Addon");
       done();
@@ -37,8 +34,8 @@ describe("lib/utils", function () {
   });
 
   it("getManifest() returns {} when no package.json found", function (done) {
-    process.chdir(path.join(__dirname, "..", "addons"));
-    utils.getManifest().then(function(manifest) {
+    var noAddonDir = path.join(__dirname, "..", "addons");
+    utils.getManifest(noAddonDir).then(function(manifest) {
       expect(Object.keys(manifest).length).to.be.equal(0);
       done();
     });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -54,7 +54,8 @@ function exec (args, options, callback) {
   options = options || {};
   var env = _.extend({}, options.env, process.env);
 
-  return child_process.exec("node " + jpm + " " + args, {
+  return child_process.exec("node " + jpm + " --addon-dir " + options.addonDir
+                            + " " + args, {
     cwd: options.cwd || tmpOutputDir,
     env: env
   }, function (err, stdout, stderr) {
@@ -71,7 +72,7 @@ function spawn (cmd, options) {
   var env = _.extend({}, options.env, process.env);
 
   return child_process.spawn("node", [
-    jpm, cmd, "-v", "-f", options.filter || ""
+    jpm, cmd, "-v", "--addon-dir", options.addonDir, "-f", options.filter || ""
   ],
   {
     cwd: options.cwd || tmpOutputDir,


### PR DESCRIPTION
This pull request explores the changes needed to turn jpm into a nodejs library,
which will help its integration into gulp/grunt plugins.

- [x] add a new ```--addon-dir``` jpm option (which defaults to the current work dir), and remove
  ```process.chdir/process.cwd``` usage
- [x] inject fallback ```install.rdf``` and ```bootstrap.js``` files into the generated xpi archive,
  instead of creating temporary files into the addon directory
- [x] changes in the test suite
- [ ] fix fails on iojs (https://travis-ci.org/mozilla/jpm/jobs/51972298)
- [ ] add test case which tests explicitly that ```--addon-dir``` defaults to the ```process.cwd()```
- [ ] add test cases about *jpm as library* usage