### PR TITLE
don't traverse deeper on .jpmignore dir recursive match

### DIFF
--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -106,7 +106,15 @@ function listdir (dir, rules, root, included) {
       return filter(f, rules, root, false, included);
     });
     return when.all(subdirs.map(function (d) {
-      return listdir(d, rules, root, filter(d, rules, root, true, included));
+      var rule = getFilterRule(d, rules, root, true);
+      if (rule) {
+        if (/\*\*$/.test(rule.pattern)) {
+          // Don't go deeper.
+          return;
+        }
+        return listdir(d, rules, root, rule.negate);
+      }
+      return listdir(d, rules, root, included);
     }))
     .then(function (list) {
       list = list.reduce(function (ret, i) {
@@ -132,19 +140,36 @@ function listdir (dir, rules, root, included) {
  * @return {Boolean}
  */
 function filter (p, rules, root, isDirectory, included) {
+  var rule = getFilterRule(p, rules, root, isDirectory);
+  if (rule) {
+    return rule.negate;
+  }
+  return included;
+}
+
+/**
+ * obtain the filter rule for a given file or dir
+ *
+ * @param {String}  p
+ * @param {Array}   rules
+ * @param {String}  root
+ * @param {Boolean} isDirectory
+ * @return {Object}
+ */
+function getFilterRule (p, rules, root, isDirectory) {
   p = path.relative(root, p);
   for (var i in rules) {
     var rule = rules[i];
     if (isDirectory) {
       if (rule.match(p) || rule.match("/" + p) || rule.match(p + "/") || rule.match("/" + p + "/")) {
-        return rule.negate;
+        return rule;
       }
     }
     else {
       if (rule.match(p) || rule.match("/" + p)) {
-        return rule.negate;
+        return rule;
       }
     }
   }
-  return included;
+  return null;
 }


### PR DESCRIPTION
Given `.jpmignore`:

````
<name>/**
````

will stop traversing deeper once `**$` is encountered. Need this to exclude deep directory trees which take forever to traverse. Once a `**` rule is used to match a dir it should not be possible to selectively include some files form this excluded set again this we can stop all file traversal.
