### PR TITLE
read existing user preferences

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -10,7 +10,9 @@ var when = require("when");
 var console = require("./utils").console;
 
 function copyProfile(profile) {
-  return when.resolve(new FirefoxProfile(profile));
+  var firefoxProfile = new FirefoxProfile(profile);
+  firefoxProfile._readExistingUserjs();
+  return when.resolve(firefoxProfile);
 }
 exports.copyProfile = copyProfile;
 


### PR DESCRIPTION
Depends on: https://github.com/saadtazi/firefox-profile-js/pull/49

Was not able to load in existing user preferences when specifying a profile directory using `--profile`.