### PR TITLE
Support background option

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -35,7 +35,8 @@ program
   .option("--debug", "Enable the add-on debugger when running the add-on")
   .option("--check-memory", "Enable leaked tracker that attempts to report compartments leaked")
   .option("--profile-memory", "Enable profiling of memory usage")
-  .option("--retro", "In development flag for transitioning to new style addons; forces the lack of install.rdf/bootstrap.js creation regardless of what engine versions are running");
+  .option("--retro", "In development flag for transitioning to new style addons; forces the lack of install.rdf/bootstrap.js creation regardless of what engine versions are running")
+  .option("--background", "Run Firefox in the background");
 
 program
   .command("docs")

--- a/lib/firefox.js
+++ b/lib/firefox.js
@@ -41,7 +41,7 @@ function runFirefox (manifest, options) {
   return fxRunner({
     "binary": options.binary,
     "no-remote": true,
-    "foreground": true,
+    "foreground": !options.background,
     "profile": profilePath,
     env: extend({}, process.env, require("./firefox-env.json")),
     verbose: options.verbose,


### PR DESCRIPTION
I want to introduce `--background` option which runs Firefox in background. Currently firefox always gains focus on every `jpm test` which is sometimes very annoying as I loose focus from the current app when `jpm test` runs on change.

With `--background` option I can keep having firefox on background between launches.