### PR TITLE
Implements `jpm new name`, which runs `jpm init` inside a new folder…

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -6,6 +6,7 @@ var console = require("../lib/utils").console;
 var run = require("../lib/run");
 var test = require("../lib/test");
 var xpi = require("../lib/xpi");
+var new_ = require("../lib/new");
 var init = require("../lib/init");
 var cmd = require("../lib/cmd");
 var open = require("open");
@@ -106,6 +107,13 @@ program
       process.exit(results.code);
     }, console.error);
   }));
+
+program
+  .command("new [name]")
+  .description("Creates a new directory and runs `jpm init` in it")
+  .action(function(name) {
+    new_(name).then(process.exit);
+  });
 
 program
   .command("init")

--- a/lib/init-input.js
+++ b/lib/init-input.js
@@ -5,6 +5,7 @@
 
 var path = require("path");
 var MIN_VERSION = require("./settings").MIN_VERSION;
+var sanitizeName = require("./utils").sanitizeName;
 var semver = require("semver");
 
 module.exports = {
@@ -29,18 +30,6 @@ function identity (x) {
   return x;
 }
 
-/**
- * Takes a string and filters out anything that is not
- * a letter, number, or dash (-) and casts to lower case.
- *
- * @param {String} name
- * @return {String}
- */
-
-function sanitizeName (name) {
-  name = name || "";
-  return name.replace(/[^\w-]|_/g,'').toLowerCase();
-}
 
 /**
  * Takes a version string ('1.0.4') and ensures it is a valid semver

--- a/lib/new.js
+++ b/lib/new.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+var fs = require("fs-promise");
+var path = require("path");
+var when = require("when");
+var init = require("./init");
+var sanitizeName = require("./utils").sanitizeName;
+
+function new_(name, options) {
+  return when.promise(function(resolve, reject) {
+      if (!name) {
+          return reject("`jpm new` requires a name to be specified.")
+      }
+
+      if (name === ".") {
+          return reject("Trying to generate an addon in this directory? Use " +
+                        "`jpm init` instead.");
+      }
+
+      var sanitizedName = sanitizeName(name);
+
+      var absPath = path.join(process.cwd(), sanitizedName);
+
+      fs.mkdir(absPath, function(err) {
+        if (err) {
+          return reject("A project named \"" + name + "\" already exists.");
+        } else {
+          process.chdir(absPath);
+          return resolve();
+        }
+      });
+  })
+    .then(init)
+    .catch(console.error);
+}
+
+module.exports = new_;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,3 +91,16 @@ function getManifest () {
   })
 }
 exports.getManifest = getManifest;
+
+/**
+ * Takes a string and filters out anything that is not
+ * a letter, number, or dash (-) and casts to lower case.
+ *
+ * @param {String} name
+ * @return {String}
+ */
+function sanitizeName (name) {
+    name = name || "";
+    return name.replace(/[^\w-]|_/g,'').toLowerCase();
+}
+exports.sanitizeName = sanitizeName;

--- a/test/functional/test.init.js
+++ b/test/functional/test.init.js
@@ -12,6 +12,9 @@ var chai = require("chai");
 var expect = chai.expect;
 var exec = utils.exec;
 
+var respond = utils.respond;
+var generateResponses = utils.generateResponses;
+
 var capitalAddonPath = path.join(__dirname, "..", "fixtures", "Capital-name");
 
 describe("jpm init", function () {
@@ -208,37 +211,3 @@ describe("jpm init", function () {
   });
 });
 
-/**
- * Takes a process and array of strings. Everytime stdout emits its
- * data event, the helper writes to stdin in order of the strings array.
- * Also takes an optional function to respond to every stdout `data`
- * event before writing to stdin.
- *
- * @param {Object} proc
- * @param {Array} responses
- * @param {Function} fn
- * @return {Object}
- */
-
-function respond (proc, responses, fn) {
-  var count = 0;
-  proc.stdout.on("data", sendResponse);
-  function sendResponse (data) {
-    if (fn)
-      fn(data);
-    proc.stdin.write(responses[count++], "utf-8");
-
-    if (count > responses.length) {
-      proc.stdout.off("data", sendResponse);
-      proc.stdin.end();
-    }
-  }
-  return proc;
-}
-
-// Create 8 empty responses and a "yes"
-function generateResponses () {
-  var responses = Array(9).join("\n").split("");
-  responses.push("yes\n");
-  return responses;
-}

--- a/test/functional/test.new.js
+++ b/test/functional/test.new.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+var fs = require("fs");
+var utils = require("../utils");
+var path = require("path");
+var exec = utils.exec;
+var respond = utils.respond;
+var generateResponses = utils.generateResponses;
+var chai = require("chai");
+var expect = chai.expect;
+var when = require("when");
+
+describe("jpm new", function () {
+    beforeEach(utils.setup);
+    afterEach(utils.tearDown);
+
+    it("does not create a new addon if no name is given", function (done) {
+        var proc = exec("new", {}, function (err, stdout, stderr) {
+            expect(stderr).to.contain("requires a name");
+            done();
+        });
+    });
+
+    it("does not create a new addon if name is `.`", function (done) {
+        var proc = exec("new .", {}, function (err, stdout, stderr) {
+            expect(stderr).to.contain("Use `jpm init` instead");
+            done();
+        });
+    });
+
+    it("creates an addon called `name` in a new folder", function (done) {
+        process.chdir(utils.tmpOutputDir);
+        var responses = generateResponses();
+
+        var proc = respond(exec("new jetpack"), responses);
+        proc.on("close", function() {
+            expect(fs.existsSync(path.join(utils.tmpOutputDir, "jetpack")))
+              .to.equal(true);
+            expect(fs.existsSync(path.join(utils.tmpOutputDir, "jetpack/package.json")))
+              .to.equal(true);
+            done();
+        });
+        proc.once("exit", function(code) {
+            expect(code).to.equal(0);
+        });
+    });
+});

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -161,3 +161,39 @@ function isTravis() {
   return (process.env.JPM_FIREFOX_BINARY == "travis");
 }
 exports.isTravis = isTravis;
+
+/**
+ * Takes a process and array of strings. Everytime stdout emits its
+ * data event, the helper writes to stdin in order of the strings array.
+ * Also takes an optional function to respond to every stdout `data`
+ * event before writing to stdin.
+ *
+ * @param {Object} proc
+ * @param {Array} responses
+ * @param {Function} fn
+ * @return {Object}
+ */
+function respond (proc, responses, fn) {
+    var count = 0;
+    proc.stdout.on("data", sendResponse);
+    function sendResponse (data) {
+        if (fn)
+            fn(data);
+        proc.stdin.write(responses[count++], "utf-8");
+
+        if (count > responses.length) {
+            proc.stdout.off("data", sendResponse);
+            proc.stdin.end();
+        }
+    }
+    return proc;
+}
+exports.respond = respond;
+
+// Create 8 empty responses and a "yes"
+function generateResponses () {
+    var responses = Array(9).join("\n").split("");
+    responses.push("yes\n");
+    return responses;
+}
+exports.generateResponses = generateResponses;


### PR DESCRIPTION
… named `name`

Coming from ember-cli, the [command to get started](http://www.ember-cli.com/user-guide/#using-ember-cli) with a new ember app is

```bash
$ ember new my-app
```

Jpm [instead tells you to](https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Getting_Started_%28jpm%29#Initializing_an_empty_add-on) 

```bash
$ mkdir my-addon
$ cd my-addon
$ jpm init
```

This seemed to be two commands too many so I implemented `jpm new my-addon`. I now have a renewed appreciation for the shell, which does in 3 lines what Javascript does in roughly 100.

Since this is a new command, I hope it avoids the concerns from #242, which I sadly only discovered after I finished writing this PR. For instance, `jpm new` saves an entire keystroke from `jpm init`. Multiply that by the tens of people using jpm annually and we might save an entire minute of aggregate developer time per year! Now that would certainly be an accomplishment for my résumé.