### PR TITLE
Adds cmd line option to specify the xpi filename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npm link
 * `--prefs [path]` Uses a JSON file or common js file which exports a JSON object.  The keys of this object will be the pref names, the values will be the pref values.
 * `-o, --overload [path]` Uses either the specified `[path]` or the path set in the environment variables `JETPACK_ROOT` as the root for [addon-sdk](https://github.com/mozilla/addon-sdk) modules instead of the ones built into Firefox.
 * `--post-url <URL>` **experimental** Used to post a xpi to a URL.
+* `--xpi-filename <filename>` Specify the filename of the `.xpi` file.
 
 ### Commands
 

--- a/bin/jpm
+++ b/bin/jpm
@@ -35,7 +35,8 @@ program
   .option("--debug", "Enable the add-on debugger when running the add-on")
   .option("--check-memory", "Enable leaked tracker that attempts to report compartments leaked")
   .option("--profile-memory", "Enable profiling of memory usage")
-  .option("--retro", "In development flag for transitioning to new style addons; forces the lack of install.rdf/bootstrap.js creation regardless of what engine versions are running");
+  .option("--retro", "In development flag for transitioning to new style addons; forces the lack of install.rdf/bootstrap.js creation regardless of what engine versions are running")
+  .option("--xpi-filename <filename>", "Specify the filename of the xpi file");
 
 program
   .command("docs")

--- a/lib/xpi.js
+++ b/lib/xpi.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-var join = require("path").join;
+var path = require("path");
 var getID = require("jetpack-id");
 var validate = require("./validate");
 var hasAOMSupport = require("./utils").hasAOMSupport;
@@ -27,9 +27,14 @@ var _ = require("lodash");
 function xpi (manifest, options) {
   options = options || {};
   var xpiVersion = manifest.version ? ("-" + manifest.version) : "";
-  var xpiName = getID(manifest) + xpiVersion + ".xpi";
+  var xpiName = options.xpiFilename ? options.xpiFilename : getID(manifest) + xpiVersion;
+  
+  if (path.extname(xpiName) !== ".xpi") {
+    xpiName += ".xpi";
+  }
+ 
   var dir = process.cwd();
-  var xpiPath = join(options.xpiPath || dir, xpiName);
+  var xpiPath = path.join(options.xpiPath || dir, xpiName);
   var useFallbacks = !(options.forceAOM || hasAOMSupport(manifest));
 
   options = _.merge(options, {


### PR DESCRIPTION
When running the xpi command to package up the add-on, it is useful to
be able to set the output filename explicitly so it doesn't have to be
renamed elsewhere in the build chain. This change adds the command line
option --xpi-filename to explicitly set a filename.

Fixes #315.