### PR TITLE
Don't show additional firstrun page on official builds

### DIFF
--- a/data/preferences.js
+++ b/data/preferences.js
@@ -53,6 +53,7 @@ exports.DEFAULT_FENNEC_PREFS = {
 exports.DEFAULT_FIREFOX_PREFS = {
     "browser.startup.homepage" : "about:blank",
     "startup.homepage_welcome_url" : "about:blank",
+    "startup.homepage_welcome_url.additional" : "",
     "devtools.errorconsole.enabled" : true,
     "devtools.chrome.enabled" : true,
 


### PR DESCRIPTION
This was pointed out on IRC, see http://logs.glob.uno/?c=mozilla%23jetpack&s=6+Nov+2015&e=6+Nov+2015#c124782 and other  bits of that log.

This page was added for official branding (release + beta) in https://bugzilla.mozilla.org/show_bug.cgi?id=1209140 . We should override it so people testing their add-on don't see it every. single. time.

@jsantell , can you take a look?