### PR TITLE
Make key/secret required options for jpm sign

### DIFF
--- a/lib/sign.js
+++ b/lib/sign.js
@@ -5,6 +5,7 @@
 
 var _ = require("lodash");
 var getID = require("jetpack-id");
+var when = require("when");
 
 var DefaultAMOClient = require("./amo-client").Client;
 var xpi = require("./xpi");
@@ -16,14 +17,36 @@ function sign (manifest, program, options, config) {
     AMOClient: DefaultAMOClient,
   }, config);
 
-  var client = new config.AMOClient({
-    apiKey: options.apiKey, apiSecret: options.apiSecret,
-    apiUrlPrefix: options.apiUrlPrefix,
-  });
+  return when.promise(function(resolve, reject) {
 
-  return xpi(manifest, options).then(function (xpiPath) {
+    var missingOptions = [];
+    var toCheck = [
+      {value: options.apiKey, flag: '--api-key'},
+      {value: options.apiSecret, flag: '--api-secret'},
+    ];
+    toCheck.forEach(function(opt) {
+      if (!opt.value) {
+        missingOptions.push(opt.flag);
+      }
+    });
+    if (missingOptions.length) {
+      console.error();
+      missingOptions.forEach(function(flag) {
+        console.error("  error: missing required option `%s'", flag);
+      });
+      console.error();
+      return reject();
+    }
+
+    resolve(xpi(manifest, options));
+
+  }).then(function (xpiPath) {
     console.log("Successfully created xpi at " + xpiPath);
 
+    var client = new config.AMOClient({
+      apiKey: options.apiKey, apiSecret: options.apiSecret,
+      apiUrlPrefix: options.apiUrlPrefix,
+    });
     return client.sign({
       xpiPath: xpiPath, guid: getID(manifest), version: manifest.version,
     });
@@ -33,7 +56,9 @@ function sign (manifest, program, options, config) {
     config.systemProcess.exit(result.success ? 0 : 1);
   }, function (err) {
     console.log('FAIL');
-    console.error(err.stack);
+    if (err) {
+      console.error(err.stack);
+    }
     config.systemProcess.exit(1);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla-jetpack/jpm/issues/387

Looks like:
````
$ jpm sign
JPM [info] Starting jpm sign on GitHub Tab Width

  error: missing required option `--api-key'
  error: missing required option `--api-secret'

FAIL
````