### PR TITLE
Adding failed exits for errors on jpm test

### DIFF
--- a/lib/firefox.js
+++ b/lib/firefox.js
@@ -59,6 +59,7 @@ function runFirefox (manifest, options) {
         console.error("No Firefox binary found at " + binary);
         if (!options.binary) {
           console.error("Specify a Firefox binary to use with the `-b` flag.");
+          process.exit(1)
         }
       }
       else {
@@ -101,6 +102,7 @@ function runFirefox (manifest, options) {
         else {
           code = 1;
           writeLog("There were test failures...\n");
+          process.exit(1)
         }
       }
     });

--- a/lib/firefox.js
+++ b/lib/firefox.js
@@ -59,7 +59,7 @@ function runFirefox (manifest, options) {
         console.error("No Firefox binary found at " + binary);
         if (!options.binary) {
           console.error("Specify a Firefox binary to use with the `-b` flag.");
-          process.exit(1)
+          process.exit(1);
         }
       }
       else {
@@ -102,7 +102,7 @@ function runFirefox (manifest, options) {
         else {
           code = 1;
           writeLog("There were test failures...\n");
-          process.exit(1)
+          process.exit(1);
         }
       }
     });


### PR DESCRIPTION
Hopefully I placed these exits in the correct place, it's kinda hard to follow the flow.

Reason for change: CI systems that check for return code on tests will pass failures, these changes seek to cause them to fail.