### PR TITLE
Consider the xpi signed only when files are ready

### DIFF
--- a/lib/amo-client.js
+++ b/lib/amo-client.js
@@ -116,27 +116,22 @@ Client.prototype.waitForSignedAddon = function(statusUrl, opt) {
 
         var failedValidation = !data.valid;
         // The add-on passes validation and all files have been created.
-        var passedValidation = data.valid && data.reviewed;
+        var signedAndReady = (data.valid && data.reviewed && data.files &&
+                              data.files.length > 0);
 
-        if (data.processed && (failedValidation || passedValidation)) {
+        if (data.processed && (failedValidation || signedAndReady)) {
 
           self._validateProgress.finish();
           opt.clearTimeout(statusCheckTimeout);
           logger.log('Validation results:', data.validation_url);
 
-          if (data.valid) {
+          if (signedAndReady) {
             // TODO: show some validation warnings if there are any.
             // We should show things like 'missing update URL in install.rdf'
-
-            if (data.files.length === 0) {
-              return reject(new Error(
-                'Huh, the API did not return any signed files: ' + formatResponse(data)));
-            }
-            resolve(self.downloadSignedFiles(data.files));
-
+            return resolve(self.downloadSignedFiles(data.files));
           } else {
             logger.log('Your add-on failed validation and could not be signed');
-            resolve({success: false});
+            return resolve({success: false});
           }
 
         } else {


### PR DESCRIPTION
I have seen this occur both locally and on stage where the file was processed and had validation results but the files array was empty. When inspecting the DB, signed files were there so I suspect it's a race condition. It may be better fixed by adding a db transaction somewhere but, meh, that code is easy to get lost in ;) I couldn't find an obvious place to patch it.