### PR TITLE
Migrate test suite to download.mozilla.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,9 @@ before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
 
 before_script:
-  - npm install firefox-get -g
   - pwd
   - cd ..
-  - wget `firefox-get -v $FIREFOX_VERSION` -O firefox.tar.bz2 && tar xvf firefox.tar.bz2
+  - wget "https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US" -O firefox.tar.bz2 && tar xvf firefox.tar.bz2
   - cd $TRAVIS_BUILD_DIR
   - pwd
 


### PR DESCRIPTION
I guess the FTP site went away so firefox-get nor mozilla-get-url work anymore.
This was blogged about here:
https://ftangftang.wordpress.com/2015/11/17/the-latest-on-firefoxreleaseslatest/