### PR TITLE
Issue #332: Added option --addon-dir (defaults to the current work dir)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm link
 * `-p, --profile <PROFILE>` Uses the profile name or path when running Firefox. Paths must start with either "./" or "/", or be considered a profile name.
 * `--prefs <path>` Uses a JSON file or common js file which exports a JSON object.  The keys of this object will be the pref names, the values will be the pref values.
 * `-o, --overload <path>` Uses either the specified `<path>` or the path set in the environment variables `JETPACK_ROOT` as the root for [addon-sdk](https://github.com/mozilla/addon-sdk) modules instead of the ones built into Firefox.
-* `--dir <path>` Specify a source directory of the add-on (instead of current directory) when building an add-on with `xpi`.
+* `--addon-dir <path>` Specify a source directory of the add-on (instead of current directory) when building an add-on with `xpi`.
 * `--post-url <URL>` **experimental** Used to post a xpi to a URL.
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ npm link
 * `--binary-args <CMDARGS>` Passes other arguments into Firefox. Enclose multiple arguments in quotes.
 * `--debug` Enable the add-on debugger when running the add-on.
 * `-p, --profile <PROFILE>` Uses the profile name or path when running Firefox. Paths must start with either "./" or "/", or be considered a profile name.
-* `--prefs [path]` Uses a JSON file or common js file which exports a JSON object.  The keys of this object will be the pref names, the values will be the pref values.
-* `-o, --overload [path]` Uses either the specified `[path]` or the path set in the environment variables `JETPACK_ROOT` as the root for [addon-sdk](https://github.com/mozilla/addon-sdk) modules instead of the ones built into Firefox.
+* `--prefs <path>` Uses a JSON file or common js file which exports a JSON object.  The keys of this object will be the pref names, the values will be the pref values.
+* `-o, --overload <path>` Uses either the specified `<path>` or the path set in the environment variables `JETPACK_ROOT` as the root for [addon-sdk](https://github.com/mozilla/addon-sdk) modules instead of the ones built into Firefox.
+* `--dir <path>` Specify a source directory of the add-on (instead of current directory) when building an add-on with `xpi`.
 * `--post-url <URL>` **experimental** Used to post a xpi to a URL.
 
 ### Commands
@@ -66,11 +67,11 @@ Run current add-on with Firefox Nightly on OSX:
 
     jpm run -b nightly
 
-Turn current add-on into a `.xpi` file for deployment and installation
+Turn add-on in the current directory into a `.xpi` file for deployment and installation:
 
     jpm xpi
 
-Use local checkout of SDK modules for working on the SDK itself.
+Use local checkout of SDK modules for working on the SDK itself:
 
     jpm run -o /path/to/addon-sdk
 

--- a/bin/jpm
+++ b/bin/jpm
@@ -27,6 +27,7 @@ program
   .option("-o, --overload [path]", "Overloads the built-in Firefox SDK modules with a local copy located at environment variable `JETPACK_ROOT` or `path` if supplied. Used for development on the SDK itself.")
   .option("-f, --filter <pattern>", "--filter=FILENAME[:TESTNAME] only run tests whose filenames match FILENAME and " +
                       "optionally match TESTNAME, both regexps")
+  .option("--addon-dir <path>", "Path of Firefox addon to build.", process.cwd())
   .option("--binary-args <CMDARGS>", "Pass additional arguments into Firefox.")
   .option("--prefs <path>", "Custom set user preferences (path to a json file)")
   .option("--post-url <url>", "A url to post a xpi of your extension")
@@ -140,4 +141,3 @@ program.parse(process.argv);
 if (cmd.isEmptyCommand(program)) {
   program.help();
 }
-

--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -11,7 +11,7 @@ var DEBUG_VALUES = ["binary", "verbose", "binaryArgs", "overload", "profile"];
 
 function prepare (mode, program, actionCallback) {
   return function (commanderOptions) {
-    return utils.getManifest().then(function(manifest) {
+    return utils.getManifest({addonDir: program.addonDir}).then(function(manifest) {
       validateProgram(program);
       console.log("Starting jpm " + mode + " on " +
                   (manifest.title || manifest.name));

--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -8,7 +8,6 @@ var fs = require("fs-promise");
 var when = require("when");
 var Minimatch = require("minimatch").Minimatch;
 var utils  = require("./utils");
-var getManifest = utils.getManifest;
 var console = utils.console;
 var getID = require("jetpack-id");
 
@@ -23,7 +22,7 @@ var getID = require("jetpack-id");
 function ignore (dir, options) {
   var jpmignore = path.join(dir, ".jpmignore");
   var default_rules = ["*.zip", ".*", "test/", ".jpmignore"];
-  return getManifest()
+  return utils.getManifest({ addonDir: options.addonDir })
   .then(function(manifest) {
     // add the xpi file name to the ignore list
     var xpiName = getID(manifest) + "*.xpi";

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -42,7 +42,7 @@ function sign (program, options, config) {
     }
     cmd.validateProgram(program);
 
-    var withManifest = config.getManifest({xpiPath: options.xpi})
+    var withManifest = config.getManifest({addonDir: options.addonDir, xpiPath: options.xpi})
       .then(function(manifest) {
         var xpiConfig = {
           manifest: manifest,

--- a/lib/task.js
+++ b/lib/task.js
@@ -28,7 +28,7 @@ function removeXPI(options) {
 }
 
 function execute(manifest, options) {
-  options = options || {};
+  options = options || { addonDir: process.cwd() };
   var id = getID(manifest);
 
   if (~["run", "test"].indexOf(options.command)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,16 +87,16 @@ exports.console = Object.freeze(jpmConsole);
  *          Without this, the current working directory is assumed.
  * @return {Promise} resolves to a manifest object
  */
-function getManifest (options) {
+function getManifest(options) {
   options = _.assign({
-    xpiPath: null,
+    addonDir: null,
+    xpiPath: null
   }, options);
   return when.promise(function(resolve, reject) {
     if (options.xpiPath) {
       return resolve(getXPIManifest(options.xpiPath));
     } else {
-      var cwd = process.cwd();
-      var json = path.join(cwd, "package.json");
+      var json = path.join(options.addonDir, "package.json");
       var manifest = {};
       try {
         manifest = require(json);

--- a/lib/xpi.js
+++ b/lib/xpi.js
@@ -26,15 +26,16 @@ var _ = require("lodash");
 
 function xpi (manifest, options) {
   options = options || {};
+  var addonDir = options.addonDir || process.cwd();
   var xpiVersion = manifest.version ? ("-" + manifest.version) : "";
   var xpiName = getID(manifest) + xpiVersion + ".xpi";
   var updateRdfName = getID(manifest) + xpiVersion + ".update.rdf";
-  var dir = process.cwd();
-  var xpiPath = join(options.xpiPath || dir, xpiName);
-  var updateRdfPath = join(options.xpiPath || dir, updateRdfName);
+  var xpiPath = join(options.xpiPath || addonDir, xpiName);
+  var updateRdfPath = join(options.xpiPath || addonDir, updateRdfName);
   var useFallbacks = !(options.forceAOM || hasAOMSupport(manifest));
 
   options = _.merge(options, {
+    addonDir: addonDir,
     xpiName: xpiName,
     xpiPath: xpiPath,
     useFallbacks: useFallbacks,
@@ -49,7 +50,7 @@ function xpi (manifest, options) {
         if (options.verbose) {
           console.log("Validating the manifest")
         }
-        return validate(dir);
+        return validate(options.addonDir);
       }
       return null;
     })

--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -23,9 +23,8 @@ function getData (xml, tag) {
 exports.getData = getData;
 
 function checkNeedsFallbacks(options) {
-  var dir = process.cwd();
-  var rdfPath = join(dir, "install.rdf");
-  var bsPath = join(dir, "bootstrap.js");
+  var rdfPath = join(options.addonDir, "install.rdf");
+  var bsPath = join(options.addonDir, "bootstrap.js");
 
   if (!options.useFallbacks) {
     options.needsInstallRDF = false;
@@ -66,28 +65,26 @@ exports.checkNeedsFallbacks = checkNeedsFallbacks;
 // Creates bootstrap.js/install.rdf -- will be removed once
 // AOM is updated
 function createFallbacks (options) {
-  var dir = process.cwd();
-  var rdfPath = join(dir, "install.rdf");
-  var bsPath = join(dir, "bootstrap.js");
+  var rdfPath = join(options.addonDir, "install.rdf");
+  var bsPath = join(options.addonDir, "bootstrap.js");
   var bootstrapSrc = options.bootstrapSrc;
 
   if (options.useFallbacks && options.verbose) {
     console.log("Creating fallbacks if they are necessary..");
   }
 
-  return getManifest().then(function(manifest) {
+  return getManifest({ addonDir: options.addonDir }).then(function(manifest) {
     return when.all([
       options.needsInstallRDF ? fs.writeFile(rdfPath, RDF.createRDF(manifest)) : when.resolve(),
       options.needsBootstrapJS ? fs.copy(bootstrapSrc, bsPath) : when.resolve(),
-    ])
+    ]);
   });
 }
 exports.createFallbacks = createFallbacks;
 
 function removeFallbacks (options) {
-  var dir = process.cwd();
-  var rdfPath = join(dir, "install.rdf");
-  var bsPath = join(dir, "bootstrap.js");
+  var rdfPath = join(options.addonDir, "install.rdf");
+  var bsPath = join(options.addonDir, "bootstrap.js");
 
   if (options.useFallbacks && options.verbose) {
     console.log("Removing fallbacks if they were necessary..");
@@ -102,7 +99,7 @@ exports.removeFallbacks = removeFallbacks;
 
 function createZip (options) {
   var start = Date.now();
-  var dir = process.cwd();
+  var dir = options.addonDir;
 
   if (options.verbose) {
     console.log("Creating XPI...");
@@ -118,11 +115,11 @@ exports.createZip = createZip;
 
 function createUpdateRDF (options, updateRdfPath) {
   var deferred = when.defer();
-  
+
   if (options.verbose) {
     console.log("Creating updateRDF...");
   }
-  return getManifest().then(function(manifest) {
+  return getManifest({ addonDir: options.addonDir }).then(function(manifest) {
     if (!manifest.updateLink || options.skipUpdateRDF){
       return;
     }

--- a/test/addon_runners/test.addon_runners.js
+++ b/test/addon_runners/test.addon_runners.js
@@ -25,7 +25,7 @@ describe("jpm run addons", function () {
       var addonPath = path.join(addonsPath, file);
       process.chdir(addonPath);
 
-      var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
       if (process.env.DISPLAY) {
         options.env.DISPLAY = process.env.DISPLAY;
       }

--- a/test/addons/test.addons.js
+++ b/test/addons/test.addons.js
@@ -23,9 +23,8 @@ describe("jpm test addons", function () {
   .forEach(function (file) {
     it(file, function (done) {
       var addonPath = path.join(addonsPath, file);
-      process.chdir(addonPath);
 
-      var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
       if (process.env.DISPLAY) {
         options.env.DISPLAY = process.env.DISPLAY;
       }

--- a/test/documentation/words.txt
+++ b/test/documentation/words.txt
@@ -9,6 +9,7 @@ wget
 osx
 post-url
 binary-args
+addon-dir
 watchpost
 prefs
 ctrl

--- a/test/functional/test.run.js
+++ b/test/functional/test.run.js
@@ -302,7 +302,6 @@ describe("jpm run", function () {
       });
 
       it("run with options should receive options (--filter)", function(done) {
-        process.chdir(paramDumpPath);
         var cmd = "run -v --profile-memory --check-memory --filter bar --times 3 --stop-on-error --do-not-quit --tbpl"
         var task = exec(cmd, options, function(error, stdout, stderr) {
           expect(error).to.not.be.ok;
@@ -331,7 +330,6 @@ describe("jpm run", function () {
       });
 
       it("run with options should receive options (-f)", function(done) {
-        process.chdir(paramDumpPath);
         var cmd = "run -v --profile-memory --check-memory -f bar --times 3 --stop-on-error --do-not-quit --tbpl"
         var task = exec(cmd, options, function(error, stdout, stderr) {
           expect(error).to.not.be.ok;

--- a/test/functional/test.run.js
+++ b/test/functional/test.run.js
@@ -40,7 +40,6 @@ describe("jpm run", function () {
 
   it("should not overwrite or delete xpi in current xpi", function (done) {
     var size = null;
-    process.chdir(paramDumpPath);
     // Copy over a different xpi and rename it to the would-be generated xpi name
     fs.copy(path.join(__dirname, "..", "xpis", "@aom-unsupported.xpi"), path.join(paramDumpPath, "@param-dump.xpi")).then(function () {
       return fs.stat(path.join(paramDumpPath, "@param-dump.xpi"));
@@ -48,7 +47,7 @@ describe("jpm run", function () {
       size = stat.size;
       expect(size).to.be.greaterThan(0);
 
-      var options = { cwd: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         fs.stat(path.join(paramDumpPath, "@param-dump.xpi")).then(function (stat) {
@@ -75,7 +74,7 @@ describe("jpm run", function () {
 
     it("does not overload if overload set and JETPACK_ROOT is not set", function (done) {
       process.env.JETPACK_ROOT = "";
-      var options = { cwd: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -o -v", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.not.contain("OVERLOADED STARTUP");
@@ -86,7 +85,7 @@ describe("jpm run", function () {
 
     it("overloads the SDK if overload set and JETPACK_ROOT set", function (done) {
       process.env.JETPACK_ROOT = path.join(__dirname, "../fixtures/mock-sdk");
-      var options = { cwd: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -o -v", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("OVERLOADED STARTUP");
@@ -97,7 +96,7 @@ describe("jpm run", function () {
     it("overloads the SDK with [path] if set over JETPACK_ROOT", function (done) {
       process.env.JETPACK_ROOT = "/an/invalid/path";
       var sdkPath = path.join(__dirname, "../fixtures/mock-sdk");
-      var options = { cwd: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -v -o " + sdkPath, options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("OVERLOADED STARTUP");
@@ -108,7 +107,7 @@ describe("jpm run", function () {
     it("overloads the SDK if overload set and uses [path] if given", function (done) {
       process.env.JETPACK_ROOT = "";
       var sdkPath = path.join(__dirname, "../fixtures/mock-sdk");
-      var options = { cwd: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: overloadablePath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -v -o " + sdkPath, options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("OVERLOADED STARTUP");
@@ -120,8 +119,7 @@ describe("jpm run", function () {
 
   describe("-v/--verbose", function () {
     it("logs out only console messages from the addon without -v", function (done) {
-      process.chdir(paramDumpPath);
-      var options = { cwd: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("console\.log: param-dump:")
@@ -131,8 +129,7 @@ describe("jpm run", function () {
     });
 
     it("logs out everything from console with -v", function (done) {
-      process.chdir(paramDumpPath);
-      var options = { cwd: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run -v", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout.split("\n").length).to.be.gt(2);
@@ -143,8 +140,7 @@ describe("jpm run", function () {
     });
 
     it("logs errors without `verbose`", function (done) {
-      process.chdir(errorAddonPath);
-      var options = { cwd: errorAddonPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: errorAddonPath, env: { JPM_FIREFOX_BINARY: binary }};
       var proc = exec("run", options, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stderr).to.contain("ReferenceError");
@@ -155,8 +151,7 @@ describe("jpm run", function () {
 
   describe("-b/--binary <BINARY>", function () {
     it("Uses specified binary instead of default Firefox", function (done) {
-      process.chdir(simpleAddonPath);
-      var proc = exec("run -b " + fakeBinary, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -b " + fakeBinary, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-foreground -no-remote -profile");
         done();
@@ -166,8 +161,7 @@ describe("jpm run", function () {
 
   describe("--binary-args <CMDARGS>", function () {
     it("Passes in additional arguments to Firefox (single)", function (done) {
-      process.chdir(simpleAddonPath);
-      var proc = exec("run -v -b " + fakeBinary + " --binary-args -some-value", { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " --binary-args -some-value", { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-some-value");
         done();
@@ -175,8 +169,7 @@ describe("jpm run", function () {
     });
 
     it("Passes in additional arguments to Firefox (multiple)", function (done) {
-      process.chdir(simpleAddonPath);
-      var proc = exec("run -v -b " + fakeBinary + " --binary-args \"-one -two -three\"", { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " --binary-args \"-one -two -three\"", { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-one -two -three");
         done();
@@ -186,8 +179,7 @@ describe("jpm run", function () {
 
   describe("-p/--profile", function () {
     it("Passes in a new temporary profile path to Firefox when -profile is not set", function (done) {
-      process.chdir(simpleAddonPath);
-      var proc = exec("run -v -b " + fakeBinary, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-profile ");
         expect(stdout).to.not.contain("-no-copy");
@@ -196,9 +188,8 @@ describe("jpm run", function () {
     });
 
     it("Passes in a temporary profile path instead of the original", function (done) {
-      process.chdir(simpleAddonPath);
       var tempProfile = new FirefoxProfile();
-      var proc = exec("run -v -b " + fakeBinary + " -p " + tempProfile.profileDir, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " -p " + tempProfile.profileDir, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-profile ");
         expect(stdout).to.not.contain("-profile " + tempProfile.profileDir);
@@ -208,9 +199,8 @@ describe("jpm run", function () {
     });
 
     it("Does not pass in a temporary profile path instead of the original with --no-copy", function (done) {
-      process.chdir(simpleAddonPath);
       var tempProfile = new FirefoxProfile();
-      var proc = exec("run -v -b " + fakeBinary + " --no-copy -p " + tempProfile.profileDir, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " --no-copy -p " + tempProfile.profileDir, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-profile ");
         expect(stdout).to.contain("-profile " + tempProfile.profileDir);
@@ -220,9 +210,8 @@ describe("jpm run", function () {
     });
 
     it("--no-copy alone passes in a temporary profile path instead of the original", function (done) {
-      process.chdir(simpleAddonPath);
       var tempProfile = new FirefoxProfile();
-      var proc = exec("run -v -b " + fakeBinary + " --no-copy -p " + tempProfile.profileDir, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+      var proc = exec("run -v -b " + fakeBinary + " --no-copy -p " + tempProfile.profileDir, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stdout).to.contain("-profile " + tempProfile.profileDir);
         expect(stdout).to.not.contain("-no-copy");
@@ -231,7 +220,6 @@ describe("jpm run", function () {
     });
 
     it("Passes in a profile name results in -p <path>", function (done) {
-      process.chdir(simpleAddonPath);
       var binary = process.env.JPM_FIREFOX_BINARY || "nightly";
 
       // find firefox nightly
@@ -256,7 +244,7 @@ describe("jpm run", function () {
           then(function(profilePath) {
             var cmd = "run -v -b " + fakeBinary + " -p jpm-test";
             // jpm run -b fakeBinary -p jpm-test
-            var proc = exec(cmd, { cwd: simpleAddonPath }, function (err, stdout, stderr) {
+            var proc = exec(cmd, { addonDir: simpleAddonPath }, function (err, stdout, stderr) {
               expect(err).to.not.be.ok;
               expect(stdout).to.not.contain("-P jpm-test");
               expect(stdout).to.not.contain("-profile " + profilePath);
@@ -269,7 +257,7 @@ describe("jpm run", function () {
     });
 
     describe("options passed to an add-on", function() {
-      var options = { cwd: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary } }
+      var options = { addonDir: paramDumpPath, env: { JPM_FIREFOX_BINARY: binary } }
 
       function readParams(stdout) {
         var output = stdout.toString()
@@ -288,7 +276,6 @@ describe("jpm run", function () {
       }
 
       it("run with only -v option", function(done) {
-        process.chdir(paramDumpPath);
         var task = exec("run -v", options, function(error, stdout, stderr) {
           expect(error).to.not.be.ok;
           //expect(stderr).to.not.be.ok;
@@ -375,8 +362,7 @@ describe("jpm run", function () {
 
   describe("SDK context", function () {
     it("@loader/options#metadata loads in package.json", function (done) {
-      process.chdir(loaderOptionsPath);
-      var options = { cwd: loaderOptionsPath, env: { JPM_FIREFOX_BINARY: binary }};
+      var options = { addonDir: loaderOptionsPath, env: { JPM_FIREFOX_BINARY: binary }};
       var task = exec("run -v", options, function(error, stdout, stderr) {
         expect(error).to.not.be.ok;
 

--- a/test/functional/test.test.js
+++ b/test/functional/test.test.js
@@ -36,9 +36,8 @@ describe("jpm test", function () {
 
   it("test-success", function (done) {
     var addonPath = path.join(addonsPath, "test-success");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test", options, function (err, stdout, stderr) {
       expect(allTestPasses(stdout)).to.equal(true);
       expect(stdout).to.contain("All tests passed!");
@@ -51,9 +50,8 @@ describe("jpm test", function () {
 
   it("test-success with verbose", function (done) {
     var addonPath = path.join(addonsPath, "test-success");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test -v", options, function (err, stdout, stderr) {
       expect(allTestPasses(stdout)).to.equal(true);
       expect(stdout).to.contain("All tests passed!");
@@ -66,9 +64,8 @@ describe("jpm test", function () {
 
   it("test-failure", function (done) {
     var addonPath = path.join(addonsPath, "test-failure");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test", options, function (err, stdout, stderr) {
       expect(oneTestFails(stdout)).to.equal(true);
       expect(stdout).to.not.contain("All tests passed!");
@@ -83,9 +80,8 @@ describe("jpm test", function () {
 
   it("test-failure with verbose", function (done) {
     var addonPath = path.join(addonsPath, "test-failure");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test -v", options, function (err, stdout, stderr) {
       expect(oneTestFails(stdout)).to.equal(true);
       expect(stdout).to.not.contain("All tests passed!");
@@ -101,9 +97,8 @@ describe("jpm test", function () {
 
   it("test-logging-german-char", function (done) {
     var addonPath = path.join(addonsPath, "test-logging-german-char");
-    process.chdir(addonPath);
 
-    var options = { cwd: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
+    var options = { addonDir: addonPath, env: { JPM_FIREFOX_BINARY: binary }};
     var proc = exec("test -v", options, function (err, stdout, stderr) {
       expect(allTestPasses(stdout)).to.equal(true);
       expect(stdout).to.contain("All tests passed!");

--- a/test/functional/test.xpi.js
+++ b/test/functional/test.xpi.js
@@ -16,9 +16,8 @@ describe("jpm xpi", function () {
   beforeEach(utils.setup);
   afterEach(utils.tearDown);
 
-  it("creates a xpi of the cwd", function (done) {
-    process.chdir(simpleAddonPath);
-    var proc = exec("xpi", { cwd: simpleAddonPath });
+  it("creates a xpi of the simple-addon", function (done) {
+    var proc = exec("xpi", { addonDir: simpleAddonPath });
     proc.on("close", function () {
       var xpiPath = path.join(simpleAddonPath, "@simple-addon-1.0.0.xpi");
 

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -599,16 +599,13 @@ describe('amoClient.PseudoProgress', function() {
 
 describe('sign', function() {
   var simpleAddonPath = path.join(__dirname, "..", "fixtures", "simple-addon");
-  var manifest;
   var mockProcessExit;
   var mockProcess;
   var signingCall;
 
   beforeEach(function() {
     utils.setup();
-    process.chdir(simpleAddonPath);
     signingCall = null;
-    manifest = require(path.join(simpleAddonPath, "package.json"));
     mockProcessExit = new CallableMock();
     mockProcess = {
       exit: mockProcessExit.getCallable(),
@@ -645,6 +642,7 @@ describe('sign', function() {
       cmdOptions: {
         apiKey: 'some-key',
         apiSecret: 'some-secret',
+        addonDir: simpleAddonPath
       },
     }, options);
 

--- a/test/unit/test.utils.js
+++ b/test/unit/test.utils.js
@@ -29,18 +29,14 @@ describe("lib/utils", function () {
   });
 
   describe("getManifest", function() {
-    it("returns manifest in cwd()", function () {
-      process.chdir(simpleAddonPath);
-      return utils.getManifest().then(function(manifest) {
+    it("returns manifest in simple-addon directory", function () {
+      return utils.getManifest({addonDir: simpleAddonPath}).then(function(manifest) {
         expect(manifest.name).to.be.equal("simple-addon");
         expect(manifest.title).to.be.equal("My Simple Addon");
       });
     });
 
     it("returns manifest from custom XPI file", function () {
-      // Change into a non-package path.
-      process.chdir(path.join(__dirname, "..", "addons"));
-
       return utils.getManifest({xpiPath: simpleAddonXPI})
         .then(function(manifest) {
           expect(manifest.name).to.be.equal("simple-addon");
@@ -70,8 +66,8 @@ describe("lib/utils", function () {
     });
 
     it("returns {} when no package.json found", function () {
-      process.chdir(path.join(__dirname, "..", "addons"));
-      return utils.getManifest().then(function(manifest) {
+      var noAddonDir = path.join(__dirname, "..", "addons");
+      return utils.getManifest({addonDir: noAddonDir}).then(function(manifest) {
         expect(Object.keys(manifest).length).to.be.equal(0);
       });
     });

--- a/test/unit/test.utils.js
+++ b/test/unit/test.utils.js
@@ -37,11 +37,13 @@ describe("lib/utils", function () {
     });
 
     it("returns manifest from custom XPI file", function () {
-      return utils.getManifest({xpiPath: simpleAddonXPI})
-        .then(function(manifest) {
-          expect(manifest.name).to.be.equal("simple-addon");
-          expect(manifest.title).to.be.equal("My Simple Addon");
-        });
+      return utils.getManifest({
+        xpiPath: simpleAddonXPI,
+        addonDir: path.join(__dirname, "..", "addons") // pass in an invalid dir just to make sure it's not used
+      }).then(function(manifest) {
+        expect(manifest.name).to.be.equal("simple-addon");
+        expect(manifest.title).to.be.equal("My Simple Addon");
+      });
     });
 
     it("throws error for non-existant XPI file", function () {

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -54,7 +54,8 @@ function exec (args, options, callback) {
   options = options || {};
   var env = _.extend({}, options.env, process.env);
 
-  return child_process.exec("node " + jpm + " " + args, {
+  return child_process.exec("node " + jpm + " --addon-dir " + options.addonDir
+                            + " " + args, {
     cwd: options.cwd || tmpOutputDir,
     env: env
   }, function (err, stdout, stderr) {
@@ -71,7 +72,7 @@ function spawn (cmd, options) {
   var env = _.extend({}, options.env, process.env);
 
   return child_process.spawn("node", [
-    jpm, cmd, "-v", "-f", options.filter || ""
+    jpm, cmd, "-v", "--addon-dir", options.addonDir, "-f", options.filter || ""
   ],
   {
     cwd: options.cwd || tmpOutputDir,

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -54,8 +54,11 @@ function exec (args, options, callback) {
   options = options || {};
   var env = _.extend({}, options.env, process.env);
 
-  return child_process.exec("node " + jpm + " --addon-dir " + options.addonDir
-                            + " " + args, {
+  var cmdLine = [ "node", jpm ];
+  if (options.addonDir) cmdLine.push("--addon-dir", options.addonDir);
+  cmdLine.push(args);
+
+  return child_process.exec(cmdLine.join(" "), {
     cwd: options.cwd || tmpOutputDir,
     env: env
   }, function (err, stdout, stderr) {
@@ -71,10 +74,11 @@ function spawn (cmd, options) {
   options = options || {};
   var env = _.extend({}, options.env, process.env);
 
-  return child_process.spawn("node", [
-    jpm, cmd, "-v", "--addon-dir", options.addonDir, "-f", options.filter || ""
-  ],
-  {
+  var cmdArgs = [ jpm, cmd, "-v" ];
+  if (options.addonDir) cmdArgs.push("--addon-dir", options.addonDir);
+  if (options.filter) cmdArgs.push("-f", options.filter);
+
+  return child_process.spawn("node", cmdArgs, {
     cwd: options.cwd || tmpOutputDir,
     env: env
   });


### PR DESCRIPTION
This solves #332: adds a new option to set the sources directory and override the process.cwd. This is an updated and polished commit from abandoned pull request #272 