### PR TITLE
Listen to write-stream end for downloads

### DIFF
--- a/lib/amo-client.js
+++ b/lib/amo-client.js
@@ -201,30 +201,26 @@ Client.prototype.downloadSignedFiles = function(signedFiles, options) {
       var fileName = path.join(process.cwd(), getUrlBasename(fileUrl));
       var out = options.createWriteStream(fileName);
 
-      var req = options.request(self.configureRequest({
-        method: 'GET',
-        url: fileUrl,
-      }));
+      options.request(self.configureRequest({
+          method: 'GET',
+          url: fileUrl,
+          followRedirect: true,
+        }))
+        .on('error', reject)
+        .on('response', function (data) {
+          var contentLength = data.headers['content-length'];
+          if (contentLength) {
+            dataExpected += parseInt(contentLength);
+          }
+        })
+        .on('data', function (chunk) {
+          dataReceived += chunk.length;
+          showProgress();
+        })
+        .pipe(out)
+        .on('error', reject);
 
-      req.on('error', function (error) {
-        reject(error);
-      });
-
-      req.pipe(out);
-
-      req.on('response', function (data) {
-        var contentLength = data.headers['content-length'];
-        if (contentLength) {
-          dataExpected += parseInt(contentLength);
-        }
-      });
-
-      req.on('data', function (chunk) {
-        dataReceived += chunk.length;
-        showProgress();
-      });
-
-      req.on('end', function() {
+      out.on('finish', function() {
         options.stdout.write('\n');  // end the progress output
         resolve(fileName);
       });

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -267,17 +267,26 @@ describe('amoClient.Client', function() {
     it('downloads signed files', function(done) {
       var fakeResponse = {
         on: function(event, handler) {
-          if (event === 'end') {
-            // Immediately complete the download.
+          return this;
+        },
+        pipe: function() {
+          return this;
+        },
+      };
+
+      var fakeFileWriter = {
+        on: function(event, handler) {
+          if (event === 'finish') {
+            // Simulate completion of the download immediately when the
+            // handler is registered.
             handler();
           }
         },
-        pipe: function() {},
-      };
+      }
 
       var files = signedResponse().responseBody.files;
       var fakeRequest = new CallableMock({returnValue: fakeResponse});
-      var createWriteStream = new CallableMock();
+      var createWriteStream = new CallableMock({returnValue: fakeFileWriter});
 
       this.client.downloadSignedFiles(files, {
         request: fakeRequest.getCallable(),


### PR DESCRIPTION
For some reason the old way of listening to 'end' on the response was saving incomplete files fetched from the CDN. This approach works.