### PR TITLE
jpm sign: show debug logging with --verbose

### DIFF
--- a/lib/amo-client.js
+++ b/lib/amo-client.js
@@ -4,6 +4,7 @@
 "use strict";
 
 var _ = require('lodash');
+var deepcopy = require('deepcopy');
 var fs = require('fs');
 var url = require('url');
 var path = require('path');
@@ -11,7 +12,7 @@ var jwt = require('jsonwebtoken');
 var request = require('request');
 var when = require("when");
 var nodefn = require('when/node');
-var logger = require("./utils").console;
+var defaultLogger = require("./utils").console;
 
 
 /**
@@ -22,16 +23,21 @@ var logger = require("./utils").console;
  *   - `apiSecret`: API secret string from the Developer Hub.
  *   - `apiUrlPrefix`: API URL prefix, including any leading paths.
  *   - `signedStatusCheckInterval`: A period in millesconds between
+ *   - `debugLogging`: When true, log more information
  *     checks when waiting on add-on signing.
  */
 function Client(conf) {
   conf = _.assign({
+    debugLogging: false,
     signedStatusCheckInterval: 1000,
+    logger: defaultLogger,
   }, conf);
   this.apiKey = conf.apiKey;
   this.apiSecret = conf.apiSecret;
   this.apiUrlPrefix = conf.apiUrlPrefix;  // default set in CLI options.
   this.signedStatusCheckInterval = conf.signedStatusCheckInterval;
+  this.debugLogging = conf.debugLogging;
+  this.logger = conf.logger;
 
   // Set up external dependencies, allowing for overrides.
   this._validateProgress = conf.validateProgress || new PseudoProgress({
@@ -71,8 +77,8 @@ Client.prototype.sign = function(conf) {
     var acceptableStatuses = [200, 201, 202];
     if (acceptableStatuses.indexOf(httpResponse.statusCode) === -1) {
       if (typeof response === 'object' && response.error) {
-        logger.error('Server response:', response.error,
-                     '( status:', httpResponse.statusCode, ')');
+        self.logger.error('Server response:', response.error,
+                          '( status:', httpResponse.statusCode, ')');
         return {success: false};
       }
 
@@ -126,19 +132,19 @@ Client.prototype.waitForSignedAddon = function(statusUrl, opt) {
 
           self._validateProgress.finish();
           opt.clearTimeout(statusCheckTimeout);
-          logger.log('Validation results:', data.validation_url);
+          self.logger.log('Validation results:', data.validation_url);
 
           if (requiresManualReview) {
-            logger.log('Your add-on has been submitted for review. It passed ' +
-                       'validation but could not be automatically signed ' +
-                       'with the type of certificate you requested.');
+            self.logger.log('Your add-on has been submitted for review. It passed ' +
+                            'validation but could not be automatically signed ' +
+                            'with the type of certificate you requested.');
             return resolve({success: false});
           } else if (signedAndReady) {
             // TODO: show some validation warnings if there are any.
             // We should show things like 'missing update URL in install.rdf'
             return resolve(self.downloadSignedFiles(data.files));
           } else {
-            logger.log('Your add-on failed validation and could not be signed');
+            self.logger.log('Your add-on failed validation and could not be signed');
             return resolve({success: false});
           }
 
@@ -245,9 +251,9 @@ Client.prototype.downloadSignedFiles = function(signedFiles, options) {
     resolve(when.all(allDownloads));
 
   }).then(function(downloadedFiles) {
-    logger.log('Downloaded:');
+    self.logger.log('Downloaded:');
     downloadedFiles.forEach(function(fileName) {
-      logger.log('    ' + fileName.replace(process.cwd(), '.'));
+      self.logger.log('    ' + fileName.replace(process.cwd(), '.'));
     });
     return {success: true};
   });
@@ -382,6 +388,7 @@ Client.prototype.request = function(method, requestConf, options) {
   var self = this;
   return when.promise(function(resolve, reject) {
     requestConf = self.configureRequest(requestConf);
+    self.debug('[API] ->', requestConf);
 
     options = _.assign({
       throwOnBadResponse: true,
@@ -418,12 +425,50 @@ Client.prototype.request = function(method, requestConf, options) {
       try {
         body = JSON.parse(body);
       } catch(e) {
-        logger.log('Failed to parse JSON response from server:', e);
+        self.logger.log('Failed to parse JSON response from server:', e);
       }
     }
+    self.debug('[API] <-',
+               {headers: httpResponse.headers, response: body});
 
     return [httpResponse, body];
   });
+};
+
+
+/**
+ * Output some debugging info if this instance is configured for it.
+ */
+Client.prototype.debug = function() {
+  if (!this.debugLogging) {
+    return;
+  }
+
+  function redact(obj) {
+    if (typeof obj !== 'object' || !obj) {
+      return obj;
+    }
+    if (obj.headers) {
+      ['Authorization', 'cookie', 'set-cookie'].forEach(function(hdr) {
+        if (obj.headers[hdr]) {
+          obj.headers[hdr] = '<REDACTED>';
+        }
+      });
+    }
+    Object.keys(obj).forEach(function(key) {
+      obj[key] = redact(obj[key]);
+    });
+    return obj;
+  }
+
+  var args = Array.prototype.map.call(arguments, function(val) {
+    if (typeof val === 'object') {
+      val = deepcopy(val);
+      val = redact(val);
+    }
+    return val;
+  });
+  this.logger.debug.apply(this.logger, args);
 };
 
 

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -69,6 +69,7 @@ function sign (program, options, config) {
       apiKey: options.apiKey,
       apiSecret: options.apiSecret,
       apiUrlPrefix: options.apiUrlPrefix,
+      debugLogging: program.verbose,
     });
     return client.sign({
       xpiPath: xpiConfig.xpiPath,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "commander": "2.6.0",
+    "deepcopy": "0.5.0",
     "fs-promise": "0.3.1",
     "fs-extra": "0.16.4",
     "fx-runner": "0.0.7",


### PR DESCRIPTION
Normal output : 

````
Creating XPI
JPM [info] XPI created at /Users/kumar/tmp/addons/scratchX-3/@scratchx-3-0.0.1.xpi (25ms)
Created XPI at /Users/kumar/tmp/addons/scratchX-3/@scratchx-3-0.0.1.xpi
JPM [info] Created XPI for signing: /Users/kumar/tmp/addons/scratchX-3/@scratchx-3-0.0.1.xpi
JPM [error] Server response: Version already exists. ( status: 409 )
JPM [info] FAIL
````

With `--verbose` : 

````
JPM [info] verbose set
JPM [info] Checking compatability bootstrap.js and install.rdf for xpi
Validating the manifest
JPM [info] Creating fallbacks if they are necessary..
Creating XPI
JPM [info] Creating XPI...
JPM [warning] .jpmignore does not exist, fallback to use default filter rules
JPM [info] Adding: /Users/kumar/tmp/addons/scratchX-3/README.md
JPM [info] Adding: /Users/kumar/tmp/addons/scratchX-3/bootstrap.js
JPM [info] Adding: /Users/kumar/tmp/addons/scratchX-3/index.js
JPM [info] Adding: /Users/kumar/tmp/addons/scratchX-3/install.rdf
JPM [info] Adding: /Users/kumar/tmp/addons/scratchX-3/package.json
JPM [info] Adding: /Users/kumar/tmp/addons/scratchX-3/scratch_x_3-0.0.1-fx+an.xpi
JPM [info] XPI created at /Users/kumar/tmp/addons/scratchX-3/@scratchx-3-0.0.1.xpi (26ms)
JPM [info] Removing fallbacks if they were necessary..
JPM [info] Creating updateRDF...
Created XPI at /Users/kumar/tmp/addons/scratchX-3/@scratchx-3-0.0.1.xpi
JPM [info] Created XPI for signing: /Users/kumar/tmp/addons/scratchX-3/@scratchx-3-0.0.1.xpi
JPM [debug] [API] -> { url: 'http://olympia.dev/api/v3/addons/%40scratchx-3/versions/0.0.1/',
  formData:
   { upload:
      { _readableState: [Object],
        readable: true,
        domain: null,
        _events: [Object],
        _maxListeners: undefined,
        path: '/Users/kumar/tmp/addons/scratchX-3/@scratchx-3-0.0.1.xpi',
        fd: null,
        flags: 'r',
        mode: 438,
        start: undefined,
        end: undefined,
        autoClose: true,
        pos: undefined } },
  headers:
   { Authorization: 'JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1c2VyOjE6Nzc2IiwiaWF0IjoxNDQ5MDc2NDYyLCJleHAiOjE0NDkwNzY1MjJ9.UR9X6bH_WHnwgRDdpDEFwc5ZAbXpYXU3EeeOSzNvg0M',
     Accept: 'application/json' } }
JPM [debug] [API] <- { headers:
   { server: 'nginx/1.9.5',
     date: 'Wed, 02 Dec 2015 17:14:22 GMT',
     'content-type': 'application/json',
     'transfer-encoding': 'chunked',
     connection: 'close',
     'content-security-policy-report-only': 'script-src \'self\' https://www.google.com https://www.paypalobjects.com https://ssl.google-analytics.com; default-src * data:; style-src * \'unsafe-inline\'; frame-src https://ssl.google-analytics.com; object-src \'none\'; report-uri /services/csp/report',
     vary: 'Accept, X-Mobile, User-Agent',
     'x-frame-options': 'DENY',
     allow: 'GET, PUT, HEAD, OPTIONS',
     'set-cookie': [ 'multidb_pin_writes=y; expires=Wed, 02-Dec-2015 17:14:37 GMT; Max-Age=15; Path=/' ] },
  response: { error: 'Version already exists.' } }
JPM [error] Server response: Version already exists. ( status: 409 )
JPM [info] FAIL
````