### PR TITLE
Fix message about valid, listed add-ons

### DIFF
--- a/lib/amo-client.js
+++ b/lib/amo-client.js
@@ -147,7 +147,7 @@ Client.prototype.waitForSignedAddon = function(statusUrl, opt) {
           if (requiresManualReview) {
             self.logger.log('Your add-on has been submitted for review. It passed ' +
                             'validation but could not be automatically signed ' +
-                            'with the type of certificate you requested.');
+                            'because this is a listed add-on.');
             return resolve({success: false});
           } else if (signedAndReady) {
             // TODO: show some validation warnings if there are any.


### PR DESCRIPTION
This is due to a policy change: https://blog.mozilla.org/addons/2015/12/01/de-coupling-reviews-from-signing-unlisted-add-ons/