### PR TITLE
Require 'when' module in post.js

### DIFF
--- a/lib/post.js
+++ b/lib/post.js
@@ -8,6 +8,7 @@ var xpi = require("./xpi");
 var fs = require("fs");
 var url = require("url");
 var net = require("net");
+var when = require("when");
 
 function postXPI (manifest, options) {
   var postURL = options.postUrl;


### PR DESCRIPTION
The `postXpi` in `libs/post.js` cannot be called directly like this: `var post = require('jpm/lib/post');` because `when` is not defined in the module scope.

When calling post, the code breaks here: https://github.com/mozilla-jetpack/jpm/blob/master/lib/post.js#L16.

Ready for code review @FayneAldan @kumar303 