### PR TITLE
Allow users to specify `sign` polling timeout

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -72,6 +72,7 @@ program
   .option("--api-secret <secret>", "addons.mozilla.org API secret string")
   .option("--api-url-prefix <urlPrefix>", "addons.mozilla.org API URL prefix [" + AMO_API_PREFIX + "]", AMO_API_PREFIX)
   .option("--xpi <filePath>", "optional XPI to be signed. By default, an XPI will be built from your working directory")
+  .option("--timeout <milliseconds>", "time to wait for success/failure response")
   .action(function(options) {
     sign(program, options);
   });

--- a/lib/amo-client.js
+++ b/lib/amo-client.js
@@ -38,6 +38,7 @@ function Client(conf) {
   this.signedStatusCheckInterval = conf.signedStatusCheckInterval;
   this.debugLogging = conf.debugLogging;
   this.logger = conf.logger;
+  this.abortAfter = conf.abortAfter || 60000;
 
   // Set up external dependencies, allowing for overrides.
   this._validateProgress = conf.validateProgress || new PseudoProgress({
@@ -102,14 +103,15 @@ Client.prototype.sign = function(conf) {
  * @return {Promise}
  */
 Client.prototype.waitForSignedAddon = function(statusUrl, opt) {
+  var self = this;
+  var lastStatusResponse;
+
   opt = _.assign({
     clearTimeout: clearTimeout,
     setAbortTimeout: setTimeout,
     setStatusCheckTimeout: setTimeout,
-    abortAfter: 60000,
+    abortAfter: self.abortAfter
   }, opt);
-  var self = this;
-  var lastStatusResponse;
 
   return when.promise(function(resolve, reject) {
     self._validateProgress.animate();

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -87,6 +87,7 @@ function sign (program, options, config) {
       apiSecret: options.apiSecret,
       apiUrlPrefix: options.apiUrlPrefix,
       debugLogging: program.verbose,
+      abortAfter: options.timeout
     });
     return client.sign({
       xpiPath: xpiConfig.xpiPath,


### PR DESCRIPTION
The extension signing process seems to take much much longer than the hardcoded 60sec magic number. This allows user input to supercede it.