### PR TITLE
Use FF beta instead of nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,32 +4,17 @@ node_js:
   - "0.10"
   - "4"
   - "5"
-env:
-  - FIREFOX_VERSION=nightly
-#  - FIREFOX_VERSION=aurora
-#  - FIREFOX_VERSION=beta
-#  - FIREFOX_VERSION=release
-
+addons:
+  firefox: latest-beta
 notifications:
   irc: "irc.mozilla.org#jpm"
-
 before_install:
-  - "export DISPLAY=:99.0"
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
   - npm install -g npm
-
 install:
   - npm install
-
-before_script:
-  - pwd
-  - cd ..
-  - wget "https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US" -O firefox.tar.bz2 && tar xvf firefox.tar.bz2
-  - cd $TRAVIS_BUILD_DIR
-  - pwd
-
 script:
-  - export JPM_FIREFOX_BINARY=$TRAVIS_BUILD_DIR/../firefox/firefox
-  - export JPM_BUILD_TYPE=travis
+  - export JPM_FIREFOX_BINARY=`which firefox`
   - npm run-script jshint
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
   irc: "irc.mozilla.org#jpm"
 before_install:
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
   - npm install -g npm
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ before_install:
   - npm install -g npm
 install:
   - npm install
+
+# To use firefox nightly, uncomment the following lines:
+# before_script:
+#   - pwd
+#   - cd ..
+#   - wget "https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US" -O firefox.tar.bz2 && tar xvf firefox.tar.bz2
+
 script:
   - export JPM_FIREFOX_BINARY=`which firefox`
   - npm run-script jshint

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -163,6 +163,6 @@ function invalidResolve () {
 exports.invalidResolve = invalidResolve;
 
 function isTravis() {
-  return (process.env.JPM_FIREFOX_BINARY == "travis");
+  return (process.env.TRAVIS == 'true');
 }
 exports.isTravis = isTravis;


### PR DESCRIPTION
I'm not sure we need to be manually downloading and installing firefox on travis, since travis already provides a mechanism for using firefox. It's possible we could simplify the travis.yml file like this.

See issue #258