### PR TITLE
Expose sign API

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -12,7 +12,7 @@ var open = require("open");
 var postXPI = require("../lib/post");
 var watch = require("node-watch");
 var cp = require('child_process');
-var sign = require("../lib/sign");
+var signCmd = require("../lib/sign").signCmd;
 var _ = require("lodash");
 
 var AMO_API_PREFIX = require("../lib/settings").AMO_API_PREFIX;
@@ -75,17 +75,7 @@ program
   .option("--xpi <filePath>", "optional XPI to be signed. By default, an XPI will be built from your working directory")
   .option("--timeout <milliseconds>", "time to wait for a signing result")
   .action(function(options) {
-    cmd.validateProgram(program);
-    sign(_.assign(options, program)).then(function (result) {
-      console.log(result.success ? 'SUCCESS' : 'FAIL');
-      process.exit(result.success ? 0 : 1);
-    }, function (err) {
-      console.error('FAIL');
-      if (err) {
-        console.error(err.stack);
-      }
-      process.exit(1);
-    });
+    signCmd(program, options);
   });
 
 program

--- a/bin/jpm
+++ b/bin/jpm
@@ -13,7 +13,6 @@ var postXPI = require("../lib/post");
 var watch = require("node-watch");
 var cp = require('child_process');
 var signCmd = require("../lib/sign").signCmd;
-var _ = require("lodash");
 
 var AMO_API_PREFIX = require("../lib/settings").AMO_API_PREFIX;
 // TODO: use .jpmignore file here instead

--- a/bin/jpm
+++ b/bin/jpm
@@ -13,8 +13,9 @@ var postXPI = require("../lib/post");
 var watch = require("node-watch");
 var cp = require('child_process');
 var sign = require("../lib/sign");
+var _ = require("lodash");
 
-var AMO_API_PREFIX = "https://addons.mozilla.org/api/v3";
+var AMO_API_PREFIX = require("../lib/settings").AMO_API_PREFIX;
 // TODO: use .jpmignore file here instead
 var IGNORE_FILES_REGEX = /(?:bootstrap\.js|install\.rdf|\.xpi)$/i;
 
@@ -74,7 +75,17 @@ program
   .option("--xpi <filePath>", "optional XPI to be signed. By default, an XPI will be built from your working directory")
   .option("--timeout <milliseconds>", "time to wait for a signing result")
   .action(function(options) {
-    sign(program, options);
+    cmd.validateProgram(program);
+    sign(_.assign(options, program)).then(function (result) {
+      console.log(result.success ? 'SUCCESS' : 'FAIL');
+      process.exit(result.success ? 0 : 1);
+    }, function (err) {
+      console.error('FAIL');
+      if (err) {
+        console.error(err.stack);
+      }
+      process.exit(1);
+    });
   });
 
 program

--- a/index.js
+++ b/index.js
@@ -2,5 +2,3 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
-
-module.exports.sign = require('./lib/sign').sign;

--- a/index.js
+++ b/index.js
@@ -2,3 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
+
+module.exports.sign = require('./lib/sign');

--- a/index.js
+++ b/index.js
@@ -3,4 +3,4 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-module.exports.sign = require('./lib/sign');
+module.exports.sign = require('./lib/sign').sign;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -12,6 +12,8 @@ exports.MAX_VERSION = "43.0";
 // This isn't implemented, so crank up the AOM_SUPPORT_VERSION
 exports.AOM_SUPPORT_VERSION = "50.0a";
 
+exports.AMO_API_PREFIX = "https://addons.mozilla.org/api/v3";
+
 exports.ids = {
   FIREFOX: "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
   MOZILLA: "{86c18b42-e466-45a9-ae7a-9b95ba6f5640}",

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -22,7 +22,6 @@ function sign (options, config) {
   config = _.assign({
     createXPI: xpi,
     getManifest: utils.getManifest,
-    systemProcess: process,
     AMOClient: DefaultAMOClient,
   }, config);
 
@@ -111,6 +110,9 @@ function sign (options, config) {
 
 
 function signCmd (program, options, config) {
+  config = _.assign({
+    systemProcess: process,
+  }, config);
   return when.promise(function(resolve, reject) {
     resolve(cmd.validateProgram(program));
   }).then(function () {

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -111,8 +111,11 @@ function sign (options, config) {
 
 
 function signCmd (program, options, config) {
-  cmd.validateProgram(program);
-  return sign(_.assign(options, program), config).then(function (result) {
+  return when.promise(function(resolve, reject) {
+    resolve(cmd.validateProgram(program));
+  }).then(function () {
+    return sign(_.assign(options, program), config);
+  }).then(function (result) {
     logger.log(result.success ? 'SUCCESS' : 'FAIL');
     config.systemProcess.exit(result.success ? 0 : 1);
   }, function (err) {

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -10,6 +10,7 @@ var nodefn = require("when/node");
 var when = require("when");
 
 var DefaultAMOClient = require("./amo-client").Client;
+var cmd = require("./cmd");
 var utils = require("./utils");
 var logger = utils.console;
 var xpi = require("./xpi");
@@ -109,4 +110,21 @@ function sign (options, config) {
 }
 
 
-module.exports = sign;
+function signCmd (program, options, config) {
+  cmd.validateProgram(program);
+  return sign(_.assign(options, program), config).then(function (result) {
+    logger.log(result.success ? 'SUCCESS' : 'FAIL');
+    config.systemProcess.exit(result.success ? 0 : 1);
+  }, function (err) {
+    logger.error('FAIL');
+    if (err) {
+      console.error(err.stack);
+    }
+    config.systemProcess.exit(1);
+  });
+}
+
+module.exports = {
+    sign: sign,
+    signCmd: signCmd,
+};

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -114,7 +114,7 @@ function signCmd (program, options, config) {
   return when.promise(function(resolve, reject) {
     resolve(cmd.validateProgram(program));
   }).then(function () {
-    return sign(_.assign(options, program), config);
+    return sign(_.assign({}, options, program), config);
   }).then(function (result) {
     logger.log(result.success ? 'SUCCESS' : 'FAIL');
     config.systemProcess.exit(result.success ? 0 : 1);

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -10,19 +10,25 @@ var nodefn = require("when/node");
 var when = require("when");
 
 var DefaultAMOClient = require("./amo-client").Client;
-var cmd = require("./cmd");
 var utils = require("./utils");
 var logger = utils.console;
 var xpi = require("./xpi");
 
+var AMO_API_PREFIX = require('./settings').AMO_API_PREFIX;
 
-function sign (program, options, config) {
+
+function sign (options, config) {
   config = _.assign({
     createXPI: xpi,
     getManifest: utils.getManifest,
     systemProcess: process,
     AMOClient: DefaultAMOClient,
   }, config);
+
+  options = _.assign({
+      addonDir: process.cwd(),
+      apiUrlPrefix: AMO_API_PREFIX,
+  }, options);
 
   return when.promise(function(resolve, reject) {
     var missingOptions = [];
@@ -43,10 +49,9 @@ function sign (program, options, config) {
       console.error();
       return reject();
     }
-    cmd.validateProgram(program);
 
     resolve(config.getManifest({
-      addonDir: program.addonDir,
+      addonDir: options.addonDir,
       xpiPath: options.xpi,
     }));
 
@@ -66,8 +71,7 @@ function sign (program, options, config) {
         .then(function(tmpResult) {
           var tmpDir = tmpResult[0];
           var removeTmpDir = tmpResult[1];
-          // Merge the program and sub-command options.
-          var xpiOptions = _.assign({}, program, options, {
+          var xpiOptions = _.assign({}, options, {
             xpiPath: tmpDir,
           });
           return config.createXPI(manifest, xpiOptions)
@@ -86,7 +90,7 @@ function sign (program, options, config) {
       apiKey: options.apiKey,
       apiSecret: options.apiSecret,
       apiUrlPrefix: options.apiUrlPrefix,
-      debugLogging: program.verbose,
+      debugLogging: options.verbose,
       signedStatusCheckTimeout: options.timeout || undefined,
     });
     return client.sign({
@@ -101,15 +105,6 @@ function sign (program, options, config) {
       return result;
     });
 
-  }).then(function(result) {
-    logger.log(result.success ? 'SUCCESS' : 'FAIL');
-    config.systemProcess.exit(result.success ? 0 : 1);
-  }, function (err) {
-    logger.error('FAIL');
-    if (err) {
-      console.error(err.stack);
-    }
-    config.systemProcess.exit(1);
   });
 }
 

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -124,7 +124,5 @@ function signCmd (program, options, config) {
   });
 }
 
-module.exports = {
-    sign: sign,
-    signCmd: signCmd,
-};
+exports.sign = sign;
+exports.signCmd = signCmd;

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -12,7 +12,7 @@ var expect = chai.expect;
 var jwt = require('jsonwebtoken');
 var when = require("when");
 
-var signCmd = require('../../lib/sign');
+var signCmd = require('../../lib/sign').signCmd;
 var amoClient = require('../../lib/amo-client');
 var utils = require("../utils");
 
@@ -830,7 +830,7 @@ describe('sign', function() {
       cmdConfig.createXPI = options.createXPI;
     }
 
-    return signCmd(_.assign(options.program, options.cmdOptions), cmdConfig);
+    return signCmd(options.program, options.cmdOptions, cmdConfig);
   }
 
   it('should exit 0 on signing success', function(done) {

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -830,7 +830,7 @@ describe('sign', function() {
       cmdConfig.createXPI = options.createXPI;
     }
 
-    return signCmd(options.program, options.cmdOptions, cmdConfig);
+    return signCmd(_.assign(options.program, options.cmdOptions), cmdConfig);
   }
 
   it('should exit 0 on signing success', function(done) {


### PR DESCRIPTION
Ref:  #86, #327

With this patch, I can sign my XPI programmatically:
```
var sign = require('/path/to/jpm').sign;
var fs = require('fs');

fs.readFile('./secrets.json', {encoding: 'utf-8'}, function (err, data) {
    if (err) {
        throw err;
    }
    var secrets = JSON.parse(data);
    sign({
        apiKey: secrets.key,
        apiSecret: secrets.secret,
    }).then(function (result) {
        console.log(result);
    }, function (err) {
        throw err;
    });
});
```
Testing:
```
$ node --stack_trace_limit=100 signXpi.js
JPM [warning] Using existing bootstrap.js. This file is usually auto-generated.
Creating XPI
JPM [info] XPI created at /tmp/tmp-unsigned-xpi-72008qSiM5Hk1m50/@newtabnews-0.0.10.xpi (84ms)
Created XPI at /tmp/tmp-unsigned-xpi-72008qSiM5Hk1m50/@newtabnews-0.0.10.xpi
JPM [info] Created XPI for signing: /tmp/tmp-unsigned-xpi-72008qSiM5Hk1m50/@newtabnews-0.0.10.xpi
Validating add-on [............................................................................................]JPM [info] Validation results: https://addons.mozilla.org/en-US/developers/upload/(some hex value)
Downloading signed files: 100% 
JPM [info] Downloaded:
JPM [info]     ./newtab-0.0.10-fx.xpi
{ success: true }
```
Tested with node 5.3.0 on Arch Linux.