### PR TITLE
Return filenames of downloaded XPIs

### DIFF
--- a/lib/amo-client.js
+++ b/lib/amo-client.js
@@ -274,7 +274,10 @@ Client.prototype.downloadSignedFiles = function(signedFiles, options) {
     downloadedFiles.forEach(function(fileName) {
       self.logger.log("    " + fileName.replace(process.cwd(), "."));
     });
-    return {success: true};
+    return {
+      success: true,
+      downloadedFiles: downloadedFiles,
+    };
   });
 };
 

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -348,9 +348,10 @@ describe("amoClient.Client", function() {
           write: function() {},
         }
       }).then(function(result) {
+        var filePath = path.join(process.cwd(), "some-signed-file-1.2.3.xpi");
         expect(result.success).to.be.equal(true);
-        expect(createWriteStream.call[0]).to.be.equal(
-          path.join(process.cwd(), "some-signed-file-1.2.3.xpi"));
+        expect(result.downloadedFiles).to.be.deep.equal([filePath]);
+        expect(createWriteStream.call[0]).to.be.equal(filePath);
         expect(fakeRequest.call[0].url).to.be.equal(files[0].download_url);
         done();
       }).catch(done);


### PR DESCRIPTION
With that I can get filenames of downloaded XPIs:

```
var sign = require('/path/to/jpm/lib/sign').sign;
var fs = require('fs');

fs.readFile('./secrets.json', {encoding: 'utf-8'}, function (err, data) {
    if (err) {
        throw err;
    }
    var secrets = JSON.parse(data);
    sign({
        apiKey: secrets.key,
        apiSecret: secrets.secret,
    }).then(function (result) {
        if (result.success === true) {
            console.log(JSON.stringify(result.downloadedFiles));
        } else {
            console.error('Something wrong!');
        }
    }, function (err) {
        throw err;
    });
});
```
Testing:
```
$ node signXpi.js 
Creating XPI
JPM [info] XPI created at /tmp/tmp-unsigned-xpi-2816rBCtDV1ESWi5/@newtabnews-0.0.15.xpi (95ms)
Created XPI at /tmp/tmp-unsigned-xpi-2816rBCtDV1ESWi5/@newtabnews-0.0.15.xpi
JPM [info] Created XPI for signing: /tmp/tmp-unsigned-xpi-2816rBCtDV1ESWi5/@newtabnews-0.0.15.xpi
Validating add-on [............................................................................................]JPM [info] Validation results: https://addons.mozilla.org/en-US/developers/upload/(some hex number)
Downloading signed files: 100% 
JPM [info] Downloaded:
JPM [info]     ./newtab-0.0.15-fx.xpi
["/home/yen/Computer/Programming/Web/newtab_news/newtab-0.0.15-fx.xpi"]
```