### PR TITLE
Restore default behavior of getManifest()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,13 +88,15 @@ exports.console = Object.freeze(jpmConsole);
  * from this directory after a temporary XPI extraction.
  *
  * @param {Object} options
+ *        - `addonDir` directory of the add-on source code, defaulting
+ *          to the working directory.
  *        - `xpiPath` a path to an XPI file where the manifest resides.
  *          Without this, the current working directory is assumed.
  * @return {Promise} resolves to a manifest object
  */
 function getManifest(options) {
   options = _.assign({
-    addonDir: null,
+    addonDir: process.cwd(),
     xpiPath: null
   }, options);
   return when.promise(function(resolve, reject) {

--- a/test/unit/test.utils.js
+++ b/test/unit/test.utils.js
@@ -19,13 +19,15 @@ var prevDir, prevBinary;
 
 describe("lib/utils", function() {
   beforeEach(function() {
-    if (process.env.JPM_FIREFOX_BINARY)
+    if (process.env.JPM_FIREFOX_BINARY) {
       prevBinary = process.env.JPM_FIREFOX_BINARY;
+    }
     prevDir = process.cwd();
   });
   afterEach(function() {
-    if (prevBinary)
+    if (prevBinary) {
       process.env.JPM_FIREFOX_BINARY = prevBinary;
+    }
     process.chdir(prevDir);
   });
 
@@ -34,6 +36,13 @@ describe("lib/utils", function() {
       return utils.getManifest({addonDir: simpleAddonPath}).then(function(manifest) {
         expect(manifest.name).to.be.equal("simple-addon");
         expect(manifest.title).to.be.equal("My Simple Addon");
+      });
+    });
+
+    it("gets the manifest from the current working dir by default", function() {
+      process.chdir(simpleAddonPath);
+      return utils.getManifest().then(function(manifest) {
+        expect(manifest.name).to.be.equal("simple-addon");
       });
     });
 


### PR DESCRIPTION
The default behavior regressed in https://github.com/mozilla-jetpack/jpm/pull/399, see https://github.com/mozilla-jetpack/jpm/commit/bb20e034a921f76f1ae6af7cfefc6697f3e34d36#commitcomment-15107293