### PR TITLE
inject bootstrap.js and install.rdf directly in the generated xpi file

### DIFF
--- a/lib/xpi.js
+++ b/lib/xpi.js
@@ -57,12 +57,10 @@ function xpi(manifest, options) {
     .then(function() {
       return utils.createFallbacks(options);
     })
-    .then(function() {
+    .then(function(fallbacks) {
+      options.fallbacks = fallbacks;
       console.log("Creating XPI");
       return utils.createZip(options);
-    })
-    .then(function() {
-      return utils.removeFallbacks(options);
     })
     .then(function() {
       return utils.createUpdateRDF(options, updateRdfPath);

--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -6,6 +6,8 @@
 var join = require("path").join;
 var when = require("when");
 var fs = require("fs-promise");
+var Zip = require("jszip");
+
 var RDF = require("../rdf");
 var zip = require("../zip");
 var console = require("../utils").console;
@@ -79,29 +81,21 @@ function createFallbacks(options) {
     addonDir: options.addonDir
   }).then(function(manifest) {
     return when.all([
-      options.needsInstallRDF ? fs.writeFile(
-        rdfPath, RDF.createRDF(manifest)) : when.resolve(),
-      options.needsBootstrapJS ? fs.copy(
-        bootstrapSrc, bsPath) : when.resolve(),
-    ]);
+      options.needsInstallRDF ? when.resolve(
+        RDF.createRDF(manifest)) : when.resolve(),
+      options.needsBootstrapJS ? when.resolve(
+        fs.readFile(bootstrapSrc)) : when.resolve(),
+    ]).then(function(fallbacks) {
+      if (fallbacks) {
+        return {
+          installRDF: fallbacks[0],
+          bootstrapJS: fallbacks[1]
+        };
+      }
+    });
   });
 }
 exports.createFallbacks = createFallbacks;
-
-function removeFallbacks(options) {
-  var rdfPath = join(options.addonDir, "install.rdf");
-  var bsPath = join(options.addonDir, "bootstrap.js");
-
-  if (options.useFallbacks && options.verbose) {
-    console.log("Removing fallbacks if they were necessary..");
-  }
-
-  return when.all([
-    options.needsInstallRDF ? fs.remove(rdfPath) : when.resolve(),
-    options.needsBootstrapJS ? fs.remove(bsPath) : when.resolve()
-  ]);
-}
-exports.removeFallbacks = removeFallbacks;
 
 function createZip(options) {
   var start = Date.now();
@@ -112,6 +106,37 @@ function createZip(options) {
   }
 
   return zip(options, dir, options.xpiPath).then(function(result) {
+    var fallbacks = options.fallbacks;
+
+    if (!fallbacks || (!fallbacks.installRDF && !fallbacks.bootstrapJS)) {
+      // return the zip file if there isn't any needed fallback file
+      return result;
+    }
+
+    return fs.readFile(options.xpiPath).then(function(data) {
+      // add the needed fallbacks files into the zip file
+      var zip = new Zip(data);
+
+      if (options.verbose && (fallbacks.installRDF || fallbacks.bootstrapJS)) {
+        console.log("Inject bootstrap.js and install.rdf in " +
+                    options.xpiPath);
+      }
+
+      if (fallbacks.installRDF) {
+        zip.file("install.rdf", fallbacks.installRDF);
+      }
+
+      if (fallbacks.bootstrapJS) {
+        zip.file("bootstrap.js", fallbacks.bootstrapJS);
+      }
+
+      var buffer = zip.generate({type: "nodebuffer"});
+
+      return fs.writeFile(result, buffer).then(function() {
+        return result;
+      });
+    });
+  }).then(function(result) {
     var diff = Date.now() - start;
     console.log("XPI created at " + options.xpiPath + " (" + diff + "ms)");
     return result;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "tmp": "0.0.28",
     "unzip": "0.1.11",
     "when": "3.7.2",
-    "zip-dir": "1.0.0"
+    "zip-dir": "1.0.0",
+    "jszip": "2.4.0"
   },
   "devDependencies": {
     "async": "1.5.0",


### PR DESCRIPTION
This PR introduces the minimal changes needed to inject the fallback bootstrap.js and install.rdf files
in the generated xpi instead of generating the temporary files in the addon dir and then removing them.