### PR TITLE
Don't download unsigned files

### DIFF
--- a/lib/amo-client.js
+++ b/lib/amo-client.js
@@ -155,8 +155,8 @@ Client.prototype.waitForSignedAddon = function(statusUrl, opt) {
           if (requiresManualReview) {
             self.logger.log(
               "Your add-on has been submitted for review. It passed " +
-                "validation but could not be automatically signed " +
-                "because this is a listed add-on.");
+              "validation but could not be automatically signed " +
+              "because this is a listed add-on.");
             return resolve({success: false});
           } else if (signedAndReady) {
             // TODO: show some validation warnings if there are any.
@@ -262,12 +262,28 @@ Client.prototype.downloadSignedFiles = function(signedFiles, options) {
   // TODO: handle 404 downloads
 
   return when.promise(function(resolve, reject) {
-    showProgress();
+    var foundUnsignedFiles = false;
     signedFiles.forEach(function(file) {
-      allDownloads.push(download(file.download_url));
+      if (file.signed) {
+        allDownloads.push(download(file.download_url));
+      } else {
+        self.debug("This file was not signed:", file);
+        foundUnsignedFiles = true;
+      }
     });
 
-    resolve(when.all(allDownloads));
+    if (allDownloads.length) {
+      if (foundUnsignedFiles) {
+        self.logger.log(
+          "Some files were not signed. Re-run with --verbose for details.");
+      }
+      showProgress();
+      resolve(when.all(allDownloads));
+    } else {
+      reject(new Error(
+        "The XPI was processed but no signed files were found. Check your " +
+        "manifest and make sure it targets Firefox as an application."));
+    }
 
   }).then(function(downloadedFiles) {
     self.logger.log("Downloaded:");


### PR DESCRIPTION
Fixes https://github.com/mozilla-jetpack/jpm/issues/470

If no files were signed at all then you will get an informative error with a traceback.

If there some files were signed but not all of them (I think this case is highly unlikely), jpm will just show a warning message and will download just the signed files.

This addresses a legitimate case where add-ons that do not target Firefox do not get signed (because why would you need them signed).