### PR TITLE
Generating compressed XPI by default and providing compression-level option to users

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -39,6 +39,7 @@ program
   .option("--binary-args <CMDARGS>", "Pass additional arguments into Firefox.")
   .option("--prefs <path>", "Custom set user preferences (path to a json file)")
   .option("--post-url <url>", "A url to post a xpi of your extension")
+  .option("--compression-level <number>", "The compression level of the generated xpi (any level between 0 (no compression) and 9 (best but slowest compression). Default level is 5)")
   .option("--stop-on-error", "Stop running tests after the first failure")
   .option("--do-not-quit", "Do not close Firefox on a test failure")
   .option("--tbpl", "Print test output in TBPL format")

--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -128,8 +128,14 @@ function createZip(options) {
       if (fallbacks.bootstrapJS) {
         zip.file("bootstrap.js", fallbacks.bootstrapJS);
       }
-
-      var buffer = zip.generate({type: "nodebuffer"});
+      var buffer = zip.generate({
+        type: "nodebuffer",
+        compression: +options.compressionLevel === 0 ? "STORE" : "DEFLATE",
+        // With DEFLATE, you can give the compression level with compressionOptions (any level between 1 (best speed) and 9 (best compression)).
+        compressionOptions : {
+          level: Math.max(1, Math.min(+options.compressionLevel || 5, 9))
+        }
+      });
 
       return fs.writeFile(result, buffer).then(function() {
         return result;


### PR DESCRIPTION
JPM similar to CFX should generate compressed XPIs by default.

Examples:
```bash
jmp xpi --compression-level 0 # no compression 
jmp xpi --compression-level 9 # best compression
jpm xpi # compression level is 5 by default
```