### PR TITLE
Fix #473: Allow arbitrary engines

### DIFF
--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -222,6 +222,9 @@ function createUpdateRDF(manifest) {
 exports.createUpdateRDF = createUpdateRDF;
 
 function getGUID(type) {
+  if (type.match(/^\{[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12}\}$/)) {
+    return type;
+  }
   return GUIDS[(type = type.toUpperCase())];
 }
 

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -333,6 +333,16 @@ describe("lib/rdf", function() {
       expect(firefox.childNodes[5].tagName).to.be.equal("em:maxVersion");
       expect(firefox.childNodes[5].childNodes[0].data).to.be.equal(MAX_VERSION);
     });
+
+    it("passes through raw GUIDs as targetApplication", function() {
+      var xml = setupRDF({ engines: {
+        "{e95a4b1e-901d-d035-4077-e95157a7a118}": "*"
+      }});
+      var apps = xml.getElementsByTagName("em:targetApplication");
+      var application = apps[0].childNodes[1]; // Description
+      expect(application.childNodes[1].tagName).to.be.equal("em:id");
+      expect(application.childNodes[1].childNodes[0].data).to.be.equal("{e95a4b1e-901d-d035-4077-e95157a7a118}");
+    });
   });
 
   describe("createUpdateRDF", function() {


### PR DESCRIPTION
I've tried to look for places to test thise and only found the direct test of the RDF generation module. I'd expect that to be enough, since the error I've seen when trying to use GUIDs for engines in the past is generated in said module (and will still be generated if an engine is neither a GUID nor a recognized engine name).