### PR TITLE
Turn addon-dir into an absolute path (fixes #483)

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -13,6 +13,7 @@ var postXPI = require("../lib/post");
 var watch = require("node-watch");
 var cp = require("child_process");
 var signCmd = require("../lib/sign").signCmd;
+var path = require("path");
 
 var AMO_API_PREFIX = require("../lib/settings").AMO_API_PREFIX;
 // TODO: use .jpmignore file here instead
@@ -35,6 +36,10 @@ program
       "whose filenames match FILENAME and " +
       "optionally match TESTNAME, both regexps")
   .option("--addon-dir <path>", "Path of Firefox addon to build.",
+          // turn into an absolute path
+          function(dir) {
+            return path.resolve(dir);
+          },
           process.cwd())
   .option("--binary-args <CMDARGS>", "Pass additional arguments into Firefox.")
   .option("--prefs <path>", "Custom set user preferences (path to a json file)")


### PR DESCRIPTION
The addonDir option seems to only work fine with absolute paths. This is
fine as long as jpm only uses those internally and for tests, but it
breaks the `jpm xpi --addon-dir ./my/addon` command. The easiest fix is
to just run a transform function on that CLI option that makes it absolute.