### PR TITLE
Actually compress the XPI (for updatable XPIs)

### DIFF
--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -129,7 +129,9 @@ function createZip(options) {
         zip.file("bootstrap.js", fallbacks.bootstrapJS);
       }
 
-      var buffer = zip.generate({type: "nodebuffer"});
+      var buffer = zip.generate({type: "nodebuffer",
+                                 compression: "DEFLATE",
+                                 compressionOptions: {level: 6}});
 
       return fs.writeFile(result, buffer).then(function() {
         return result;


### PR DESCRIPTION
Fixes https://github.com/mozilla-jetpack/jpm/issues/474