### PR TITLE
set max version as a wild card by default

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -6,9 +6,10 @@
 // Set minimum version to 38.0a1, because some SDK changes are necessary.
 // Must be "38.0a1", as 38.0a1 < 38.0 according to how Firefox does versioning
 exports.MIN_VERSION = "38.0a1";
-// Set a MAX_VERSION to use in install.rdf - this needs to be updated every once in a while
+// Set a MAX_VERSION to use in install.rdf - set max version as a wild card.
+// Firefox only checks max version for binary add-ons.
 // see this page for supported ranges: https://addons.mozilla.org/en-US/firefox/pages/appversions/
-exports.MAX_VERSION = "43.0";
+exports.MAX_VERSION = "*";
 // This isn't implemented, so crank up the AOM_SUPPORT_VERSION
 exports.AOM_SUPPORT_VERSION = "50.0a";
 


### PR DESCRIPTION
JPM should create max version as a wild card `*` by default in install.rdf.
See [jpm xpi creates invalid install.rdf · Issue #461 · mozilla-jetpack/jpm](https://github.com/mozilla-jetpack/jpm/issues/461).
