### PR TITLE
Allow relative path for icon url

### DIFF
--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -78,6 +78,13 @@ function createRDF(manifest, needsBootstrapJS) {
     delete jetpackMeta["em:icon64URL"];
   }
 
+  /*
+   * When bootstrap.js is not provided by the addon developer, the default
+   * bootstrap.js is used. With this bootstrap.js, the addon's resource:// URI
+   * registration occurs in resource://gre/modules/commonjs/sdk/addon/bootstrap.js.
+   * If a custom bootstrap.js is provided, the program flow mentioned above may
+   * not occur, so the real icon URLs are unknow.
+   **/
   if (needsBootstrapJS) {
     ["em:iconURL", "em:icon64URL"].forEach(function(key) {
       if (jetpackMeta[key] && jetpackMeta[key].indexOf("://") === -1) {

--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -10,10 +10,10 @@ var GUIDS = require("./settings").ids;
 var MIN_VERSION = require("./settings").MIN_VERSION;
 var MAX_VERSION = require("./settings").MAX_VERSION;
 
-const UUID_PATTERN = /^\{([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\}$/;
+var UUID_PATTERN = /^\{([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\}$/;
 
 // Copied from mozilla-central/addon-sdk/source/lib/sdk/bootstrap.js
-function realDomain (id) {
+function realDomain(id) {
   return id.lastIndexOf("@") === 0 ? id.substr(1).toLowerCase() :
     id.toLowerCase().
       replace(/@/g, "-at-").
@@ -79,9 +79,10 @@ function createRDF(manifest, needsBootstrapJS) {
   }
 
   if (needsBootstrapJS) {
-    ['em:iconURL', 'em:icon64URL'].forEach(function (key) {
+    ["em:iconURL", "em:icon64URL"].forEach(function(key) {
       if (jetpackMeta[key] && jetpackMeta[key].indexOf("://") === -1) {
-        jetpackMeta[key] = 'resource://' + realDomain(jetpackMeta["em:id"]) + '/' + jetpackMeta[key];
+        var domain = realDomain(jetpackMeta["em:id"]);
+        jetpackMeta[key] = "resource://" + domain + "/" + jetpackMeta[key];
       }
     });
   }

--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -10,6 +10,17 @@ var GUIDS = require("./settings").ids;
 var MIN_VERSION = require("./settings").MIN_VERSION;
 var MAX_VERSION = require("./settings").MAX_VERSION;
 
+const UUID_PATTERN = /^\{([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\}$/;
+
+// Copied from mozilla-central/addon-sdk/source/lib/sdk/bootstrap.js
+function realDomain (id) {
+  return id.lastIndexOf("@") === 0 ? id.substr(1).toLowerCase() :
+    id.toLowerCase().
+      replace(/@/g, "-at-").
+      replace(/\./g, "-dot-").
+      replace(UUID_PATTERN, "$1");
+}
+
 /**
  * Creates an `install.rdf` file based off of an addon's `package.json`
  * object manifest. Returns a string of the composed RDF file.
@@ -18,7 +29,7 @@ var MAX_VERSION = require("./settings").MAX_VERSION;
  * @return {String}
  */
 
-function createRDF(manifest) {
+function createRDF(manifest, needsBootstrapJS) {
   var header = [{
     name: "RDF",
     attrs: {
@@ -65,6 +76,14 @@ function createRDF(manifest) {
   }
   if (jetpackMeta["em:icon64URL"] == "icon64.png") {
     delete jetpackMeta["em:icon64URL"];
+  }
+
+  if (needsBootstrapJS) {
+    ['em:iconURL', 'em:icon64URL'].forEach(function (key) {
+      if (jetpackMeta[key] && jetpackMeta[key].indexOf("://") === -1) {
+        jetpackMeta[key] = 'resource://' + realDomain(jetpackMeta["em:id"]) + '/' + jetpackMeta[key];
+      }
+    });
   }
 
   if (manifest.preferences) {

--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -82,7 +82,7 @@ function createFallbacks(options) {
   }).then(function(manifest) {
     return when.all([
       options.needsInstallRDF ? when.resolve(
-        RDF.createRDF(manifest)) : when.resolve(),
+        RDF.createRDF(manifest, options.needsBootstrapJS)) : when.resolve(),
       options.needsBootstrapJS ? when.resolve(
         fs.readFile(bootstrapSrc)) : when.resolve(),
     ]).then(function(fallbacks) {

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -101,45 +101,70 @@ describe("lib/rdf", function() {
     });
 
     it("iconURL uses `icon` with string", function() {
-      var xml = setupRDF({ icon: "megaman.png" });
-      expect(getData(xml, "em:iconURL")).to.be.equal("megaman.png");
+      var xml = setupRDF({ id: "icon@jetpack", icon: "megaman.png" });
+      expect(getData(xml, "em:iconURL")).to.be.equal("resource://icon-at-jetpack/megaman.png");
     });
 
     it("iconURL uses `icon` with object no 48", function() {
-      var xml = setupRDF({ icon: { "32": "foo32.png" } });
-      expect(getData(xml, "em:iconURL")).to.be.equal("foo32.png");
+      var xml = setupRDF({ id: "icon@jetpack", icon: { "32": "foo32.png" } });
+      expect(getData(xml, "em:iconURL")).to.be.equal("resource://icon-at-jetpack/foo32.png");
     });
 
     // Use 48 because as of Fx 4 48 can be used in place of 32
     it("iconURL uses `icon` with object and 48", function() {
-      var xml = setupRDF({ icon: {
+      var xml = setupRDF({ id: "icon@jetpack", icon: {
         "32": "foo32.png",
         "48": "foo48.png"
       } });
-      expect(getData(xml, "em:iconURL")).to.be.equal("foo48.png");
+      expect(getData(xml, "em:iconURL")).to.be.equal("resource://icon-at-jetpack/foo48.png");
     });
 
     // Use 48 because as of Fx 4 48 can be used in place of 32
     it("iconURL uses `icon` with object with no 32", function() {
-      var xml = setupRDF({ icon: { "48": "foo48.png" } });
-      expect(getData(xml, "em:iconURL")).to.be.equal("foo48.png");
+      var xml = setupRDF({ id: "icon@jetpack", icon: { "48": "foo48.png" } });
+      expect(getData(xml, "em:iconURL")).to.be.equal("resource://icon-at-jetpack/foo48.png");
     });
 
     it("iconURL ignores default `icon.png`", function() {
-      var xml = setupRDF({ icon: "icon.png" });
+      var xml = setupRDF({ id: "icon@jetpack", icon: "icon.png" });
       expect(getData(xml, "em:iconURL")).to.be.equal(undefined);
       expect(getData(xml, "em:icon64URL")).to.be.equal(undefined);
     });
 
+    it("iconURL uses a url without modifying it", function () {
+      var xml1 = setupRDF({ id: "icon@jetpack", icon: "http://mozilla.org/icon.png" });
+      expect(getData(xml1, "em:iconURL")).to.be.equal("http://mozilla.org/icon.png");
+      var xml2 = setupRDF({ id: "icon@jetpack", icon: "chrome://icon-at-jetpack/icon.png" });
+      expect(getData(xml2, "em:iconURL")).to.be.equal("chrome://icon-at-jetpack/icon.png");
+      var xml3 = setupRDF({ id: "icon@jetpack", icon: "resource://icon-at-jetpack/megaman.png" });
+      expect(getData(xml3, "em:iconURL")).to.be.equal("resource://icon-at-jetpack/megaman.png");
+    });
+
+    it("icon64URL uses a url without modifying it", function () {
+      var xml1 = setupRDF({ id: "icon@jetpack", icon: { "64": "http://mozilla.org/icon.png" } });
+      expect(getData(xml1, "em:icon64URL")).to.be.equal("http://mozilla.org/icon.png");
+      var xml2 = setupRDF({ id: "icon@jetpack", icon: { "64": "chrome://icon-at-jetpack/icon.png" } });
+      expect(getData(xml2, "em:icon64URL")).to.be.equal("chrome://icon-at-jetpack/icon.png");
+      var xml3 = setupRDF({ id: "icon@jetpack", icon: { "64": "resource://icon-at-jetpack/megaman.png" } });
+      expect(getData(xml3, "em:icon64URL")).to.be.equal("resource://icon-at-jetpack/megaman.png");
+     });
+
     it("icon64URL uses `icon64`", function() {
-      var xml = setupRDF({ icon: { "64": "megaman.png" } });
-      expect(getData(xml, "em:icon64URL")).to.be.equal("megaman.png");
+      var xml = setupRDF({ id: "icon@jetpack", icon: { "64": "megaman.png" } });
+      expect(getData(xml, "em:icon64URL")).to.be.equal("resource://icon-at-jetpack/megaman.png");
     });
 
     it("icon64URL ignores default `icon64.png`", function() {
-      var xml = setupRDF({ icon: { "64": "icon64.png" } });
+      var xml = setupRDF({ id: "icon@jetpack", icon: { "64": "icon64.png" } });
       expect(getData(xml, "em:iconURL")).to.be.equal(undefined);
       expect(getData(xml, "em:icon64URL")).to.be.equal(undefined);
+    });
+
+    it("iconURL and icon64URL are not touched if a custom bootstrap.js provided", function() {
+      var xml1 = setupRDF({ id: "icon@jetpack", icon: { "32": "megaman.png" } }, false);
+      expect(getData(xml1, "em:iconURL")).to.be.equal("megaman.png");
+      var xml2 = setupRDF({ id: "icon@jetpack", icon: { "64": "megaman.png" } }, false);
+      expect(getData(xml2, "em:icon64URL")).to.be.equal("megaman.png");
     });
 
     it("updateURL uses `updateURL`", function() {
@@ -626,8 +651,11 @@ function parseRDF(rdf) {
   return new DOMParser().parseFromString(rdf, "application/rdf+xml");
 }
 
-function setupRDF (manifest) {
-  return parseRDF(RDF.createRDF(manifest));
+function setupRDF (manifest, needsBootstrapJS) {
+  if (typeof needsBootstrapJS == "undefined") {
+    needsBootstrapJS = true;
+  }
+  return parseRDF(RDF.createRDF(manifest, needsBootstrapJS));
 }
 
 function nodeExists (xml, tag) {


### PR DESCRIPTION
Fixes #197 and fixes #341.

It's a workaround before https://bugzilla.mozilla.org/show_bug.cgi?id=1141839 is resolved. Tested with https://github.com/whuhacker/Unblock-Youku-Firefox on Linux. If this patch is OK I'll try to add some tests.