### PR TITLE
Fix #481: Don't package signed XPI files of the extension

### DIFF
--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -9,7 +9,6 @@ var when = require("when");
 var Minimatch = require("minimatch").Minimatch;
 var utils  = require("./utils");
 var console = utils.console;
-var getID = require("jetpack-id");
 
 /**
  * Look for .jpmignore in the given directory and use it to filter files
@@ -22,12 +21,9 @@ var getID = require("jetpack-id");
  */
 function ignore(dir, options) {
   var jpmignore = path.join(dir, ".jpmignore");
-  var defaultRules = ["*.zip", ".*", "test/", ".jpmignore"];
+  var defaultRules = ["*.zip", ".*", "test/", ".jpmignore", "*.xpi"];
   return utils.getManifest({addonDir: options.addonDir})
     .then(function(manifest) {
-      // add the xpi file name to the ignore list
-      var xpiName = getID(manifest) + "*.xpi";
-      defaultRules.push(xpiName);
       return fs.exists(jpmignore);
     })
     .then(function(exists) {

--- a/test/unit/test.xpi.js
+++ b/test/unit/test.xpi.js
@@ -231,6 +231,7 @@ describe("lib/xpi", function() {
   it("Test default .jpmignore rules", function(done) {
     process.chdir(extraFilesPath);
     var ID_XPI = "extra-files@jpm.xpi";
+    var ID_SIGNED_XPI = "extra_files-0.0.1-fx.xpi";
     var manifest = require(path.join(extraFilesPath, "package.json"));
 
     // Copy in a XPI since we remove it between tests for cleanup
@@ -239,7 +240,7 @@ describe("lib/xpi", function() {
       return utils.unzipTo(xpiPath, tmpOutputDir);
     }).
     then(function() {
-      return when.all([ ".hidden", ".hidden-dir", "test", ID_XPI ]
+      return when.all([ ".hidden", ".hidden-dir", "test", ID_XPI, ID_SIGNED_XPI ]
         .map(function(p) { return path.join(tmpOutputDir, p); })
         .map(function(p) { return fs.exists(p); }))
         .then(function(results) {
@@ -249,7 +250,10 @@ describe("lib/xpi", function() {
         });
     }).
     then(function() {
-      return when.all([ ID_XPI ]
+      return fs.writeFile(path.join(extraFilesPath, ID_SIGNED_XPI), "This is not actually a signed XPI");
+    }).
+    then(function() {
+      return when.all([ ID_XPI, ID_SIGNED_XPI ]
         .map(function(p) { return path.join(extraFilesPath, p); })
         .map(function(p) { return fs.exists(p); }))
         .then(function(results) {
@@ -266,7 +270,7 @@ describe("lib/xpi", function() {
       return utils.unzipTo(xpiPath, tmpOutputDir);
     }).
     then(function() {
-      return when.all([ ".hidden", ".hidden-dir", "test", ID_XPI ]
+      return when.all([ ".hidden", ".hidden-dir", "test", ID_XPI, ID_SIGNED_XPI ]
         .map(function(p) { return path.join(tmpOutputDir, p); })
         .map(function(p) { return fs.exists(p); }))
         .then(function(results) {


### PR DESCRIPTION
Currently JPM ignores the XPI files it directly produces if there is no .jpmignore. However the XPI files generated with `jpm sign` have a different naming scheme. This patch also ignores the naming scheme from `jpm sign`. See also #481.