### PR TITLE
more tweak up about localized description

### DIFF
--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -91,21 +91,15 @@ function createRDF(manifest) {
   description.children.push(cleanMetadata(jetpackMeta));
 
   if (manifest.developers) {
-    manifest.developers.forEach(function(developer) {
-      description.children.push({"em:developer": developer});
-    });
+    aboutDeveloper(description.children, manifest.developers);
   }
 
   if (manifest.translators) {
-    manifest.translators.forEach(function(translator) {
-      description.children.push({"em:translator": translator});
-    });
+    aboutTranslator(description.children, manifest.translators);
   }
 
   if (manifest.contributors) {
-    manifest.contributors.forEach(function(contributor) {
-      description.children.push({"em:contributor": contributor});
-    });
+    aboutContributor(description.children, manifest.contributors);
   }
 
   var engines = Object.keys(manifest.engines || {});
@@ -125,9 +119,9 @@ function createRDF(manifest) {
   if (manifest.locales) {
     for (var locale in manifest.locales) {
       var l10n = manifest.locales[locale];
-      var localizedDescription = [];
+      var l10nDescription = [];
 
-      var localizedMeta = {
+      var l10nMeta = {
         "em:locale": locale,
         "em:name": l10n.title || jetpackMeta["em:name"],
         "em:description": l10n.description || jetpackMeta["em:description"],
@@ -135,33 +129,27 @@ function createRDF(manifest) {
       };
 
       if (manifest.homepage) {
-        localizedMeta["em:homepageURL"] = jetpackMeta["em:homepageURL"];
+        l10nMeta["em:homepageURL"] = jetpackMeta["em:homepageURL"];
       }
 
-      // clean localizedMeta
-      localizedDescription.push(cleanMetadata(localizedMeta));
+      // clean l10nMeta
+      l10nDescription.push(cleanMetadata(l10nMeta));
 
       if (manifest.developers) {
-        manifest.developers.forEach(function(developer) {
-          localizedDescription.push({"em:developer": developer});
-        });
+        aboutDeveloper(l10nDescription, manifest.developers);
       }
 
       if (manifest.translators) {
-        manifest.translators.forEach(function(translator) {
-          localizedDescription.push({"em:translator": translator});
-        });
+        aboutTranslator(l10nDescription, manifest.translators);
       }
 
       if (manifest.contributors) {
-        manifest.contributors.forEach(function(contributor) {
-          localizedDescription.push({"em:contributor": contributor});
-        });
+        aboutContributor(l10nDescription, manifest.contributors);
       }
 
       description.children.push({
         "em:localized": {
-          "Description": localizedDescription
+          "Description": l10nDescription
         }
       });
     }
@@ -310,4 +298,22 @@ function cleanMetadata(metadata) {
     }
   });
   return metadata;
+}
+
+function aboutDeveloper(group, members) {
+  members.forEach(function(member) {
+    group.push({"em:developer": member});
+  });
+}
+
+function aboutTranslator(group, members) {
+  members.forEach(function(member) {
+    group.push({"em:translator": member});
+  });
+}
+
+function aboutContributor(group, members) {
+  members.forEach(function(member) {
+    group.push({"em:contributor": member});
+  });
 }

--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -96,8 +96,20 @@ function createRDF(manifest) {
   description.children.push(jetpackMeta);
 
   if (manifest.developers) {
-    manifest.developers.forEach(function(dev) {
-      description.children.push({"em:developer": dev});
+    manifest.developers.forEach(function(developer) {
+      description.children.push({"em:developer": developer});
+    });
+  }
+
+  if (manifest.translators) {
+    manifest.translators.forEach(function(translator) {
+      description.children.push({"em:translator": translator});
+    });
+  }
+
+  if (manifest.contributors) {
+    manifest.contributors.forEach(function(contributor) {
+      description.children.push({"em:contributor": contributor});
     });
   }
 
@@ -115,22 +127,12 @@ function createRDF(manifest) {
     description.children.push(createApplication("Firefox"));
   }
 
-  if (manifest.translators) {
-    manifest.translators.forEach(function(translator) {
-      description.children.push({"em:translator": translator});
-    });
-  }
-
-  if (manifest.contributors) {
-    manifest.contributors.forEach(function(contributor) {
-      description.children.push({"em:contributor": contributor});
-    });
-  }
-
   if (manifest.locales) {
     for (var locale in manifest.locales) {
       var l10n = manifest.locales[locale];
-      var l10nDescription = {
+      var localizedDescription = [];
+
+      var localizedMeta = {
         "em:locale": locale,
         "em:name": l10n.title || jetpackMeta["em:name"],
         "em:description": l10n.description || jetpackMeta["em:description"],
@@ -138,12 +140,38 @@ function createRDF(manifest) {
       };
 
       if (manifest.homepage) {
-        l10nDescription["em:homepageURL"] = jetpackMeta["em:homepageURL"];
+        localizedMeta["em:homepageURL"] = jetpackMeta["em:homepageURL"];
+      }
+
+      // clean localizedMeta
+      Object.keys(localizedMeta).forEach(function(key) {
+        if (localizedMeta[key] === undefined) {
+          delete localizedMeta[key];
+        }
+      });
+      localizedDescription.push(localizedMeta);
+
+      if (manifest.developers) {
+        manifest.developers.forEach(function(developer) {
+          localizedDescription.push({"em:developer": developer});
+        });
+      }
+
+      if (manifest.translators) {
+        manifest.translators.forEach(function(translator) {
+          localizedDescription.push({"em:translator": translator});
+        });
+      }
+
+      if (manifest.contributors) {
+        manifest.contributors.forEach(function(contributor) {
+          localizedDescription.push({"em:contributor": contributor});
+        });
       }
 
       description.children.push({
         "em:localized": {
-          "Description": l10nDescription
+          "Description": localizedDescription
         }
       });
     }

--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -51,6 +51,9 @@ function createRDF(manifest) {
     "em:name": manifest.title || manifest.name || "Untitled",
     "em:description": manifest.description || undefined,
     "em:creator": formatAuthor(manifest.author),
+    "em:homepageURL": manifest.homepage || undefined,
+    "em:updateURL": manifest.updateURL || undefined,
+    "em:updateKey": manifest.updateKey || undefined,
     "em:iconURL": icon["48"] || icon["32"] || undefined,
     "em:icon64URL": icon["64"] || undefined
   };
@@ -62,18 +65,6 @@ function createRDF(manifest) {
   }
   if (jetpackMeta["em:icon64URL"] == "icon64.png") {
     delete jetpackMeta["em:icon64URL"];
-  }
-
-  if (manifest.homepage) {
-    jetpackMeta["em:homepageURL"] = manifest.homepage;
-  }
-
-  if (manifest.updateURL) {
-    jetpackMeta["em:updateURL"] = manifest.updateURL;
-  }
-
-  if (manifest.updateKey) {
-    jetpackMeta["em:updateKey"] = manifest.updateKey;
   }
 
   if (manifest.preferences) {
@@ -125,12 +116,9 @@ function createRDF(manifest) {
         "em:locale": locale,
         "em:name": l10n.title || jetpackMeta["em:name"],
         "em:description": l10n.description || jetpackMeta["em:description"],
-        "em:creator": jetpackMeta["em:creator"]
+        "em:creator": jetpackMeta["em:creator"],
+        "em:homepageURL": l10n.homepage || jetpackMeta["em:homepageURL"]
       };
-
-      if (manifest.homepage) {
-        l10nMeta["em:homepageURL"] = jetpackMeta["em:homepageURL"];
-      }
 
       // clean l10nMeta
       l10nDescription.push(cleanMetadata(l10nMeta));

--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -88,12 +88,7 @@ function createRDF(manifest) {
   header[0].children.push(description);
 
   // clean jetpackMeta
-  Object.keys(jetpackMeta).forEach(function(key) {
-    if (jetpackMeta[key] === undefined) {
-      delete jetpackMeta[key];
-    }
-  });
-  description.children.push(jetpackMeta);
+  description.children.push(cleanMetadata(jetpackMeta));
 
   if (manifest.developers) {
     manifest.developers.forEach(function(developer) {
@@ -144,12 +139,7 @@ function createRDF(manifest) {
       }
 
       // clean localizedMeta
-      Object.keys(localizedMeta).forEach(function(key) {
-        if (localizedMeta[key] === undefined) {
-          delete localizedMeta[key];
-        }
-      });
-      localizedDescription.push(localizedMeta);
+      localizedDescription.push(cleanMetadata(localizedMeta));
 
       if (manifest.developers) {
         manifest.developers.forEach(function(developer) {
@@ -311,4 +301,13 @@ function createApplication(type, versions) {
       }
     }
   };
+}
+
+function cleanMetadata(metadata) {
+  Object.keys(metadata).forEach(function(key) {
+    if (metadata[key] === undefined) {
+      delete metadata[key];
+    }
+  });
+  return metadata;
 }

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -352,7 +352,7 @@ describe("lib/rdf", function() {
           "ja" : {
             title: "名前",
             description: "紹介",
-            homepage: "ホームページ"
+            homepage: "ホームページ",
           }
         }
       });
@@ -376,7 +376,7 @@ describe("lib/rdf", function() {
         locales: {
           "ja" : {
             title: "名前",
-            homepage: "ホームページ"
+            homepage: "ホームページ",
           }
         }
       });
@@ -398,7 +398,7 @@ describe("lib/rdf", function() {
         locales: {
           "ja" : {
             title: "名前",
-            description: "紹介"
+            description: "紹介",
           }
         }
       });
@@ -422,7 +422,7 @@ describe("lib/rdf", function() {
         locales: {
           "ja" : {
             description: "紹介",
-            homepage: "ホームページ"
+            homepage: "ホームページ",
           }
         }
       });
@@ -447,12 +447,12 @@ describe("lib/rdf", function() {
           "ja" : {
             title: "名前",
             description: "紹介",
-            homepage: "ホームページ"
+            homepage: "ホームページ",
           },
           "zh-CN" : {
             title: "扩展",
             description: "说明",
-            homepage: "主页"
+            homepage: "主页",
           }
         }
       });
@@ -460,6 +460,7 @@ describe("lib/rdf", function() {
       var localeJa = locales[0].childNodes[1]; // Description
       var localeZhs = locales[1].childNodes[1]; // Description
       expect(locales.length).to.be.equal(2);
+
       expect(localeJa.tagName).to.be.equal("Description");
       expect(localeJa.childNodes[1].tagName).to.be.equal("em:locale");
       expect(localeJa.childNodes[1].childNodes[0].data).to.be.equal("ja");
@@ -470,6 +471,7 @@ describe("lib/rdf", function() {
       expect(localeJa.childNodes[7].tagName).to.be.equal("em:creator");
       expect(localeJa.childNodes[9].tagName).to.be.equal("em:homepageURL");
       expect(localeJa.childNodes[9].childNodes[0].data).to.be.equal("ホームページ");
+
       expect(localeZhs.tagName).to.be.equal("Description");
       expect(localeZhs.childNodes[1].tagName).to.be.equal("em:locale");
       expect(localeZhs.childNodes[1].childNodes[0].data).to.be.equal("zh-CN");
@@ -487,7 +489,7 @@ describe("lib/rdf", function() {
         locales: {
           "ja" : {
             title: "名前",
-            homepage: "ホームページ"
+            homepage: "ホームページ",
           },
           "zh-CN" : {
             description: "说明"
@@ -498,6 +500,7 @@ describe("lib/rdf", function() {
       var localeJa = locales[0].childNodes[1]; // Description
       var localeZhs = locales[1].childNodes[1]; // Description
       expect(locales.length).to.be.equal(2);
+
       expect(localeJa.tagName).to.be.equal("Description");
       expect(localeJa.childNodes[1].tagName).to.be.equal("em:locale");
       expect(localeJa.childNodes[1].childNodes[0].data).to.be.equal("ja");
@@ -506,6 +509,7 @@ describe("lib/rdf", function() {
       expect(localeJa.childNodes[5].tagName).to.be.equal("em:creator");
       expect(localeJa.childNodes[7].tagName).to.be.equal("em:homepageURL");
       expect(localeJa.childNodes[7].childNodes[0].data).to.be.equal("ホームページ");
+
       expect(localeZhs.tagName).to.be.equal("Description");
       expect(localeZhs.childNodes[1].tagName).to.be.equal("em:locale");
       expect(localeZhs.childNodes[1].childNodes[0].data).to.be.equal("zh-CN");

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -346,8 +346,55 @@ describe("lib/rdf", function() {
   });
 
   describe("locales", function() {
-    it("add ja localized title and description to add-on", function() {
-      var xml = setupRDF({ title: "my-title", description: "my-desc",
+    it("add `ja` title, description, and homepage to add-on", function() {
+      var xml = setupRDF({ title: "my-title", description: "my-desc", homepage: "my-page",
+        locales: {
+          "ja" : {
+            title: "名前",
+            description: "紹介",
+            homepage: "ホームページ"
+          }
+        }
+      });
+      var locales = xml.getElementsByTagName("em:localized");
+      var locale = locales[0].childNodes[1]; // Description
+      expect(locales.length).to.be.equal(1);
+      expect(locale.tagName).to.be.equal("Description");
+      expect(locale.childNodes[1].tagName).to.be.equal("em:locale");
+      expect(locale.childNodes[1].childNodes[0].data).to.be.equal("ja");
+      expect(locale.childNodes[3].tagName).to.be.equal("em:name");
+      expect(locale.childNodes[3].childNodes[0].data).to.be.equal("名前");
+      expect(locale.childNodes[5].tagName).to.be.equal("em:description");
+      expect(locale.childNodes[5].childNodes[0].data).to.be.equal("紹介");
+      expect(locale.childNodes[7].tagName).to.be.equal("em:creator");
+      expect(locale.childNodes[9].tagName).to.be.equal("em:homepageURL");
+      expect(locale.childNodes[9].childNodes[0].data).to.be.equal("ホームページ");
+    });
+
+    it("add `ja` title and homepage to add-on w/o description", function() {
+      var xml = setupRDF({ title: "my-title", homepage: "my-page",
+        locales: {
+          "ja" : {
+            title: "名前",
+            homepage: "ホームページ"
+          }
+        }
+      });
+      var locales = xml.getElementsByTagName("em:localized");
+      var locale = locales[0].childNodes[1]; // Description
+      expect(locales.length).to.be.equal(1);
+      expect(locale.tagName).to.be.equal("Description");
+      expect(locale.childNodes[1].tagName).to.be.equal("em:locale");
+      expect(locale.childNodes[1].childNodes[0].data).to.be.equal("ja");
+      expect(locale.childNodes[3].tagName).to.be.equal("em:name");
+      expect(locale.childNodes[3].childNodes[0].data).to.be.equal("名前");
+      expect(locale.childNodes[5].tagName).to.be.equal("em:creator");
+      expect(locale.childNodes[7].tagName).to.be.equal("em:homepageURL");
+      expect(locale.childNodes[7].childNodes[0].data).to.be.equal("ホームページ");
+    });
+
+    it("add `ja` title and description to add-on w/o description", function() {
+      var xml = setupRDF({ title: "my-title", homepage: "my-page",
         locales: {
           "ja" : {
             title: "名前",
@@ -365,33 +412,17 @@ describe("lib/rdf", function() {
       expect(locale.childNodes[3].childNodes[0].data).to.be.equal("名前");
       expect(locale.childNodes[5].tagName).to.be.equal("em:description");
       expect(locale.childNodes[5].childNodes[0].data).to.be.equal("紹介");
+      expect(locale.childNodes[7].tagName).to.be.equal("em:creator");
+      expect(locale.childNodes[9].tagName).to.be.equal("em:homepageURL");
+      expect(locale.childNodes[9].childNodes[0].data).to.be.equal("my-page");
     });
 
-    it("add ja localized title to add-on", function() {
-      var xml = setupRDF({ title: "my-title", description: "my-desc",
+    it("add `ja` description and homepage to add-on w/o description", function() {
+      var xml = setupRDF({ title: "my-title", homepage: "my-page",
         locales: {
           "ja" : {
-            title: "名前"
-          }
-        }
-      });
-      var locales = xml.getElementsByTagName("em:localized");
-      var locale = locales[0].childNodes[1]; // Description
-      expect(locales.length).to.be.equal(1);
-      expect(locale.tagName).to.be.equal("Description");
-      expect(locale.childNodes[1].tagName).to.be.equal("em:locale");
-      expect(locale.childNodes[1].childNodes[0].data).to.be.equal("ja");
-      expect(locale.childNodes[3].tagName).to.be.equal("em:name");
-      expect(locale.childNodes[3].childNodes[0].data).to.be.equal("名前");
-      expect(locale.childNodes[5].tagName).to.be.equal("em:description");
-      expect(locale.childNodes[5].childNodes[0].data).to.be.equal("my-desc");
-    });
-
-    it("add ja localized description to add-on", function() {
-      var xml = setupRDF({ title: "my-title", description: "my-desc",
-        locales: {
-          "ja" : {
-            description: "紹介"
+            description: "紹介",
+            homepage: "ホームページ"
           }
         }
       });
@@ -405,18 +436,23 @@ describe("lib/rdf", function() {
       expect(locale.childNodes[3].childNodes[0].data).to.be.equal("my-title");
       expect(locale.childNodes[5].tagName).to.be.equal("em:description");
       expect(locale.childNodes[5].childNodes[0].data).to.be.equal("紹介");
+      expect(locale.childNodes[7].tagName).to.be.equal("em:creator");
+      expect(locale.childNodes[9].tagName).to.be.equal("em:homepageURL");
+      expect(locale.childNodes[9].childNodes[0].data).to.be.equal("ホームページ");
     });
 
-    it("add ja & zh-CN localized title and description to add-on", function() {
-      var xml = setupRDF({ title: "my-title", description: "my-desc",
+    it("add `ja` & `zh-CN` title, description, and homepage to add-on", function() {
+      var xml = setupRDF({ title: "my-title", description: "my-desc", homepage: "my-page",
         locales: {
           "ja" : {
             title: "名前",
-            description: "紹介"
+            description: "紹介",
+            homepage: "ホームページ"
           },
           "zh-CN" : {
             title: "扩展",
-            description: "说明"
+            description: "说明",
+            homepage: "主页"
           }
         }
       });
@@ -431,6 +467,9 @@ describe("lib/rdf", function() {
       expect(localeJa.childNodes[3].childNodes[0].data).to.be.equal("名前");
       expect(localeJa.childNodes[5].tagName).to.be.equal("em:description");
       expect(localeJa.childNodes[5].childNodes[0].data).to.be.equal("紹介");
+      expect(localeJa.childNodes[7].tagName).to.be.equal("em:creator");
+      expect(localeJa.childNodes[9].tagName).to.be.equal("em:homepageURL");
+      expect(localeJa.childNodes[9].childNodes[0].data).to.be.equal("ホームページ");
       expect(localeZhs.tagName).to.be.equal("Description");
       expect(localeZhs.childNodes[1].tagName).to.be.equal("em:locale");
       expect(localeZhs.childNodes[1].childNodes[0].data).to.be.equal("zh-CN");
@@ -438,6 +477,45 @@ describe("lib/rdf", function() {
       expect(localeZhs.childNodes[3].childNodes[0].data).to.be.equal("扩展");
       expect(localeZhs.childNodes[5].tagName).to.be.equal("em:description");
       expect(localeZhs.childNodes[5].childNodes[0].data).to.be.equal("说明");
+      expect(localeZhs.childNodes[7].tagName).to.be.equal("em:creator");
+      expect(localeZhs.childNodes[9].tagName).to.be.equal("em:homepageURL");
+      expect(localeZhs.childNodes[9].childNodes[0].data).to.be.equal("主页");
+    });
+
+    it("add `ja` title and homepage & `zh-CN` description to add-on only with homepage", function() {
+      var xml = setupRDF({ homepage: "my-page",
+        locales: {
+          "ja" : {
+            title: "名前",
+            homepage: "ホームページ"
+          },
+          "zh-CN" : {
+            description: "说明"
+          }
+        }
+      });
+      var locales = xml.getElementsByTagName("em:localized");
+      var localeJa = locales[0].childNodes[1]; // Description
+      var localeZhs = locales[1].childNodes[1]; // Description
+      expect(locales.length).to.be.equal(2);
+      expect(localeJa.tagName).to.be.equal("Description");
+      expect(localeJa.childNodes[1].tagName).to.be.equal("em:locale");
+      expect(localeJa.childNodes[1].childNodes[0].data).to.be.equal("ja");
+      expect(localeJa.childNodes[3].tagName).to.be.equal("em:name");
+      expect(localeJa.childNodes[3].childNodes[0].data).to.be.equal("名前");
+      expect(localeJa.childNodes[5].tagName).to.be.equal("em:creator");
+      expect(localeJa.childNodes[7].tagName).to.be.equal("em:homepageURL");
+      expect(localeJa.childNodes[7].childNodes[0].data).to.be.equal("ホームページ");
+      expect(localeZhs.tagName).to.be.equal("Description");
+      expect(localeZhs.childNodes[1].tagName).to.be.equal("em:locale");
+      expect(localeZhs.childNodes[1].childNodes[0].data).to.be.equal("zh-CN");
+      expect(localeZhs.childNodes[3].tagName).to.be.equal("em:name");
+      expect(localeZhs.childNodes[3].childNodes[0].data).to.be.equal("Untitled");
+      expect(localeZhs.childNodes[5].tagName).to.be.equal("em:description");
+      expect(localeZhs.childNodes[5].childNodes[0].data).to.be.equal("说明");
+      expect(localeZhs.childNodes[7].tagName).to.be.equal("em:creator");
+      expect(localeZhs.childNodes[9].tagName).to.be.equal("em:homepageURL");
+      expect(localeZhs.childNodes[9].childNodes[0].data).to.be.equal("my-page");
     });
   });
 


### PR DESCRIPTION
- support `developers`,  `translators`, and `contributors` flag.
- changed the order from `engines` -> `translators` and `contributors` to `translators` and `contributors` -> `engines`
- fixed a bug that if there's no "description" in package.json, it will generate `undefined` in localized description
- some variable changes