### PR TITLE
jpm should not create blank tag <em:creator/>

### DIFF
--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -255,9 +255,9 @@ function getGUID(type) {
  */
 function formatAuthor(author) {
   if (typeof author === "object") {
-    return (author.name || "").trim();
+    return author.name || undefined;
   }
-  return author || "";
+  return author || undefined;
 }
 
 function createApplication(type, versions) {

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -220,6 +220,14 @@ describe("lib/rdf", function() {
       var xml = setupRDF({ author: { name: "Marie Curie", email: "mc@espci.fr"} });
       expect(getData(xml, "em:creator")).to.be.equal("Marie Curie");
     });
+
+    it("if `author` field is '' or undefined, do not ceate <em:creator/>", function() {
+      var xml = setupRDF({ author: "" });
+      expect(getData(xml, "em:creator")).to.be.equal(undefined);
+
+      xml = setupRDF({ author: undefined });
+      expect(getData(xml, "em:creator")).to.be.equal(undefined);
+    });
   });
 
   describe("engines", function() {

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -366,9 +366,8 @@ describe("lib/rdf", function() {
       expect(locale.childNodes[3].childNodes[0].data).to.be.equal("名前");
       expect(locale.childNodes[5].tagName).to.be.equal("em:description");
       expect(locale.childNodes[5].childNodes[0].data).to.be.equal("紹介");
-      expect(locale.childNodes[7].tagName).to.be.equal("em:creator");
-      expect(locale.childNodes[9].tagName).to.be.equal("em:homepageURL");
-      expect(locale.childNodes[9].childNodes[0].data).to.be.equal("ホームページ");
+      expect(locale.childNodes[7].tagName).to.be.equal("em:homepageURL");
+      expect(locale.childNodes[7].childNodes[0].data).to.be.equal("ホームページ");
     });
 
     it("add `ja` title and homepage to add-on w/o description", function() {
@@ -388,9 +387,8 @@ describe("lib/rdf", function() {
       expect(locale.childNodes[1].childNodes[0].data).to.be.equal("ja");
       expect(locale.childNodes[3].tagName).to.be.equal("em:name");
       expect(locale.childNodes[3].childNodes[0].data).to.be.equal("名前");
-      expect(locale.childNodes[5].tagName).to.be.equal("em:creator");
-      expect(locale.childNodes[7].tagName).to.be.equal("em:homepageURL");
-      expect(locale.childNodes[7].childNodes[0].data).to.be.equal("ホームページ");
+      expect(locale.childNodes[5].tagName).to.be.equal("em:homepageURL");
+      expect(locale.childNodes[5].childNodes[0].data).to.be.equal("ホームページ");
     });
 
     it("add `ja` title and description to add-on w/o description", function() {
@@ -412,9 +410,8 @@ describe("lib/rdf", function() {
       expect(locale.childNodes[3].childNodes[0].data).to.be.equal("名前");
       expect(locale.childNodes[5].tagName).to.be.equal("em:description");
       expect(locale.childNodes[5].childNodes[0].data).to.be.equal("紹介");
-      expect(locale.childNodes[7].tagName).to.be.equal("em:creator");
-      expect(locale.childNodes[9].tagName).to.be.equal("em:homepageURL");
-      expect(locale.childNodes[9].childNodes[0].data).to.be.equal("my-page");
+      expect(locale.childNodes[7].tagName).to.be.equal("em:homepageURL");
+      expect(locale.childNodes[7].childNodes[0].data).to.be.equal("my-page");
     });
 
     it("add `ja` description and homepage to add-on w/o description", function() {
@@ -436,9 +433,8 @@ describe("lib/rdf", function() {
       expect(locale.childNodes[3].childNodes[0].data).to.be.equal("my-title");
       expect(locale.childNodes[5].tagName).to.be.equal("em:description");
       expect(locale.childNodes[5].childNodes[0].data).to.be.equal("紹介");
-      expect(locale.childNodes[7].tagName).to.be.equal("em:creator");
-      expect(locale.childNodes[9].tagName).to.be.equal("em:homepageURL");
-      expect(locale.childNodes[9].childNodes[0].data).to.be.equal("ホームページ");
+      expect(locale.childNodes[7].tagName).to.be.equal("em:homepageURL");
+      expect(locale.childNodes[7].childNodes[0].data).to.be.equal("ホームページ");
     });
 
     it("add `ja` & `zh-CN` title, description, and homepage to add-on", function() {
@@ -468,9 +464,8 @@ describe("lib/rdf", function() {
       expect(localeJa.childNodes[3].childNodes[0].data).to.be.equal("名前");
       expect(localeJa.childNodes[5].tagName).to.be.equal("em:description");
       expect(localeJa.childNodes[5].childNodes[0].data).to.be.equal("紹介");
-      expect(localeJa.childNodes[7].tagName).to.be.equal("em:creator");
-      expect(localeJa.childNodes[9].tagName).to.be.equal("em:homepageURL");
-      expect(localeJa.childNodes[9].childNodes[0].data).to.be.equal("ホームページ");
+      expect(localeJa.childNodes[7].tagName).to.be.equal("em:homepageURL");
+      expect(localeJa.childNodes[7].childNodes[0].data).to.be.equal("ホームページ");
 
       expect(localeZhs.tagName).to.be.equal("Description");
       expect(localeZhs.childNodes[1].tagName).to.be.equal("em:locale");
@@ -479,9 +474,8 @@ describe("lib/rdf", function() {
       expect(localeZhs.childNodes[3].childNodes[0].data).to.be.equal("扩展");
       expect(localeZhs.childNodes[5].tagName).to.be.equal("em:description");
       expect(localeZhs.childNodes[5].childNodes[0].data).to.be.equal("说明");
-      expect(localeZhs.childNodes[7].tagName).to.be.equal("em:creator");
-      expect(localeZhs.childNodes[9].tagName).to.be.equal("em:homepageURL");
-      expect(localeZhs.childNodes[9].childNodes[0].data).to.be.equal("主页");
+      expect(localeZhs.childNodes[7].tagName).to.be.equal("em:homepageURL");
+      expect(localeZhs.childNodes[7].childNodes[0].data).to.be.equal("主页");
     });
 
     it("add `ja` title and homepage & `zh-CN` description to add-on only with homepage", function() {
@@ -506,9 +500,8 @@ describe("lib/rdf", function() {
       expect(localeJa.childNodes[1].childNodes[0].data).to.be.equal("ja");
       expect(localeJa.childNodes[3].tagName).to.be.equal("em:name");
       expect(localeJa.childNodes[3].childNodes[0].data).to.be.equal("名前");
-      expect(localeJa.childNodes[5].tagName).to.be.equal("em:creator");
-      expect(localeJa.childNodes[7].tagName).to.be.equal("em:homepageURL");
-      expect(localeJa.childNodes[7].childNodes[0].data).to.be.equal("ホームページ");
+      expect(localeJa.childNodes[5].tagName).to.be.equal("em:homepageURL");
+      expect(localeJa.childNodes[5].childNodes[0].data).to.be.equal("ホームページ");
 
       expect(localeZhs.tagName).to.be.equal("Description");
       expect(localeZhs.childNodes[1].tagName).to.be.equal("em:locale");
@@ -517,9 +510,8 @@ describe("lib/rdf", function() {
       expect(localeZhs.childNodes[3].childNodes[0].data).to.be.equal("Untitled");
       expect(localeZhs.childNodes[5].tagName).to.be.equal("em:description");
       expect(localeZhs.childNodes[5].childNodes[0].data).to.be.equal("说明");
-      expect(localeZhs.childNodes[7].tagName).to.be.equal("em:creator");
-      expect(localeZhs.childNodes[9].tagName).to.be.equal("em:homepageURL");
-      expect(localeZhs.childNodes[9].childNodes[0].data).to.be.equal("my-page");
+      expect(localeZhs.childNodes[7].tagName).to.be.equal("em:homepageURL");
+      expect(localeZhs.childNodes[7].childNodes[0].data).to.be.equal("my-page");
     });
   });
 


### PR DESCRIPTION
This is about https://github.com/mozilla-jetpack/jpm/pull/502#discussion-diff-54294423 . I've created a patch previously #508 , but it doesn't changed the npm authors' part, so I create this new one