### PR TITLE
! Fix error "file already exists" when using command "sign" with XPI file

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,7 @@ var tmp = require("tmp");
 var os = require("os");
 var when = require("when");
 var nodefn = require("when/node");
-var unzip = require("unzip");
+var DecompressZip = require("decompress-zip");
 var parse = require("mozilla-toolkit-versioning").parse;
 var compare = require("mozilla-version-comparator");
 var xml2js = require("xml2js");
@@ -204,16 +204,18 @@ function extractXPI(xpiPath) {
       if (err) {
         return cleanUpAndReject(err);
       }
-      fs.createReadStream(xpiPath)
-        .on("error", cleanUpAndReject)
-        .pipe(unzip.Extract({path: tmpPath}))
-        .on("error", cleanUpAndReject)
-        .on("close", function() {
-          resolve({
-            path: tmpPath,
-            remove: removeTmpDir,
-          });
+
+      var unzipper = new DecompressZip(xpiPath);
+      unzipper.on("extract", function(_log) {
+        resolve({
+          path: tmpPath,
+          remove: removeTmpDir,
         });
+      });
+      unzipper.on("error", cleanUpAndReject);
+      unzipper.extract({
+        path: tmpPath,
+      });
     }, {
       prefix: "tmp-extracted-xpi-",
       // This allows us to remove a non-empty tmp dir.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "commander": "2.9.0",
     "deepcopy": "0.5.0",
+    "decompress-zip": "0.3.0",
     "firefox-profile": "0.3.9",
     "fs-extra": "0.16.4",
     "fs-promise": "0.3.1",
@@ -55,7 +56,6 @@
     "request": "2.67.0",
     "semver": "5.1.0",
     "tmp": "0.0.28",
-    "unzip": "0.1.11",
     "when": "3.7.2",
     "xml2js": "0.4.16",
     "zip-dir": "1.0.2",

--- a/test/unit/test.utils.js
+++ b/test/unit/test.utils.js
@@ -124,7 +124,7 @@ describe("lib/utils", function() {
         .then(function() {
           throw new Error("unexpected success");
         }).catch(function(err) {
-          expect(err.message).to.include("invalid signature");
+          expect(err.message).to.include("Could not find the End of Central Directory Record");
         });
     });
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -5,7 +5,7 @@ var execFile = childProcess.execFile;
 var fs = require("fs-extra");
 var rimraf = require("rimraf");
 var glob = require("glob");
-var unzip = require("unzip");
+var DecompressZip = require("decompress-zip");
 var chai = require("chai");
 var async = require("async");
 var when = require("when");
@@ -116,9 +116,13 @@ exports.run = run;
 
 function unzipTo(xpiPath, outputDir) {
   return when.promise(function(resolve, reject) {
-    fs.createReadStream(xpiPath)
-      .pipe(unzip.Extract({path: outputDir}))
-      .on("close", resolve);
+    var unzipper = new DecompressZip(xpiPath);
+
+    unzipper.on("extract", resolve);
+    unzipper.on("error", reject);
+    unzipper.extract({
+      path: outputDir,
+    });
   });
 }
 exports.unzipTo = unzipTo;


### PR DESCRIPTION
Use another unzip library `decompress-zip` to replace `unzip` due to a potential bug in `unzip`

Fixes #458 
Tested command locally

Cause of bug:
A library used `unzip` contains a pontential bug: when unzipping a folder in zip, a file is created instead.
So the file is created multiple times causing the error.