### PR TITLE
update lodash version to 4.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jpm-core": "0.0.11",
     "jsontoxml": "0.0.11",
     "jsonwebtoken": "5.4.0",
-    "lodash": "3.10.1",
+    "lodash": "4.11.1",
     "lodash.merge": "3.3.2",
     "minimatch": "3.0.0",
     "mozilla-toolkit-versioning": "0.0.2",


### PR DESCRIPTION
The used APIs of lodash are listed:

lib/amo-client.js
lib/sign.js
lib/utils.js
test/unit/test.sign.js
`assign: since 0.10.0`

lib/firefox.js
lib/post.js
lib/preferences.js
lib/run.js
lib/test.js
test/utils/index.js
test/unit/test.profile.js
`extend: alias for assign -> alias for assignIn(4.0.0)`

lib/xpi.js
test/unit/test.sign.js
`merge: since 0.5.0`

test/utils/index.js
`flatten: since 0.1.0`