### PR TITLE
Update dependencies to remove deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "commander": "2.9.0",
     "deepcopy": "0.5.0",
     "decompress-zip": "0.3.0",
-    "firefox-profile": "0.3.9",
+    "firefox-profile": "0.4.0",
     "fs-extra": "0.30.0",
     "fs-promise": "0.3.1",
     "fx-runner": "0.0.10",


### PR DESCRIPTION
Fixes #533 

This seems to work and install correctly for me (just installing it locally).  It removes all deprecations that are emitted when running node v6.2.1 (installed on OS X via Homebrew)
