### PR TITLE
Add test on node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "0.10"
   - "4"
   - "5"
+  - "6"
 addons:
   firefox: latest-beta
 notifications:


### PR DESCRIPTION
Adding node.js version 6 to travis CI
BTW is it still necessary to test on 0.10?
