### PR TITLE
Add support for the multiprocessCompatible flag

### DIFF
--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -66,7 +66,9 @@ function createRDF(manifest, needsBootstrapJS) {
     "em:updateURL": manifest.updateURL || undefined,
     "em:updateKey": manifest.updateKey || undefined,
     "em:iconURL": icon["48"] || icon["32"] || undefined,
-    "em:icon64URL": icon["64"] || undefined
+    "em:icon64URL": icon["64"] || undefined,
+    "em:multiprocessCompatible":
+      manifest.multiprocessCompatible === true || undefined,
   };
 
   // these values are used by default so using them

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -31,6 +31,7 @@ describe("lib/rdf", function() {
       expect(getData(xml, "em:icon64URL")).to.be.equal(undefined);
       expect(getData(xml, "em:translator")).to.be.equal(undefined);
       expect(getData(xml, "em:contributor")).to.be.equal(undefined);
+      expect(getData(xml, "em:multiprocessCompatible")).to.be.equal(undefined);
       expect(str.indexOf("homepageURL")).to.be.equal(-1);
       ["description", "creator"].forEach(function(field) {
         expect(nodeEmpty(xml, "em:" + field)).to.be.equal(true);
@@ -41,6 +42,7 @@ describe("lib/rdf", function() {
       expect(nodeExists(xml, "em:icon64URL")).to.be.equal(false);
       expect(nodeExists(xml, "em:translator")).to.be.equal(false);
       expect(nodeExists(xml, "em:contributor")).to.be.equal(false);
+      expect(nodeExists(xml, "em:multiprocessCompatible")).to.be.equal(false);
     });
   });
 
@@ -73,6 +75,16 @@ describe("lib/rdf", function() {
     it("homepage uses `homepageURL`", function() {
       var xml = setupRDF({ homepage: "http://mozilla.com" });
       expect(getData(xml, "em:homepageURL")).to.be.equal("http://mozilla.com");
+    });
+
+    it("multiprocessCompatible uses `multiprocessCompatible`", function() {
+      var xml = setupRDF({ multiprocessCompatible: true });
+      expect(getData(xml, "em:multiprocessCompatible")).to.be.equal('true');
+    });
+
+    it("multiprocessCompatible does not convert non-boolean fields", function() {
+      var xml = setupRDF({ multiprocessCompatible: "yes" });
+      expect(nodeExists(xml, "em:multiprocessCompatible")).to.be.equal(false);
     });
 
     it("unpack uses `unpack`", function() {


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#multiprocessCompatible

Add-On SDK developers should have an easy way to set this without
manually touching the install.rdf. This patch allows developers to add
the flag to their package.json files.