### PR TITLE
chore: Add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
     "jpm"
   ],
   "dependencies": {
+    "any-promise": "^1.3.0",
     "commander": "2.9.0",
-    "deepcopy": "0.5.0",
     "decompress-zip": "0.3.0",
+    "deepcopy": "0.5.0",
     "firefox-profile": "0.4.0",
     "fs-extra": "0.30.0",
     "fs-promise": "0.3.1",
@@ -46,6 +47,7 @@
     "jpm-core": "0.0.11",
     "jsontoxml": "0.0.11",
     "jsonwebtoken": "5.4.0",
+    "jszip": "2.4.0",
     "lodash": "4.11.1",
     "lodash.merge": "3.3.2",
     "minimatch": "3.0.2",
@@ -58,11 +60,11 @@
     "request": "2.67.0",
     "semver": "5.1.0",
     "sign-addon": "0.1.1",
+    "thenify-all": "^1.6.0",
     "tmp": "0.0.28",
     "when": "3.7.2",
     "xml2js": "0.4.16",
-    "zip-dir": "1.0.2",
-    "jszip": "2.4.0"
+    "zip-dir": "1.0.2"
   },
   "devDependencies": {
     "async": "1.5.0",


### PR DESCRIPTION
Latest jpm version 1.1.0 isn't running properly because "any-promise" and "thenify-all" dependencies are not listed in package.json