### PR TITLE
fix: Avoid JS errors from external file from normandy.cdn.mozilla.org

### DIFF
--- a/data/preferences.js
+++ b/data/preferences.js
@@ -67,7 +67,10 @@ exports.DEFAULT_FIREFOX_PREFS = {
     "browser.safebrowsing.provider.0.updateURL" : "http://localhost/safebrowsing-dummy/update",
 
     // Disable self repair/SHIELD
-    "browser.selfsupport.url": "https://localhost/selfrepair"
+    "browser.selfsupport.url": "https://localhost/selfrepair",
+
+    // Disable Reader Mode UI tour
+    "browser.reader.detectedFirstArticle": true
 };
 
 // When launching a temporary new Thunderbird profile, use these preferences.

--- a/data/preferences.js
+++ b/data/preferences.js
@@ -64,7 +64,10 @@ exports.DEFAULT_FIREFOX_PREFS = {
     // Point the url-classifier to a nonexistent local URL for fast failures.
     "browser.safebrowsing.provider.0.gethashURL" : "http://localhost/safebrowsing-dummy/gethash",
     "browser.safebrowsing.provider.0.keyURL" : "http://localhost/safebrowsing-dummy/newkey",
-    "browser.safebrowsing.provider.0.updateURL" : "http://localhost/safebrowsing-dummy/update"
+    "browser.safebrowsing.provider.0.updateURL" : "http://localhost/safebrowsing-dummy/update",
+
+    // Disable self repair/SHIELD
+    "browser.selfsupport.url": "https://localhost/selfrepair"
 };
 
 // When launching a temporary new Thunderbird profile, use these preferences.


### PR DESCRIPTION
When running tests I'd see JS errors from a selfrepair.js. This change makes Firefox not download that file.