### PR TITLE
test: Use get-firefox to load latest unbranded release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-- '0.10'
 - '4'
 - '5'
 - '6'
@@ -25,10 +24,8 @@ before_install:
 install:
 - npm install
 before_script:
-# Install Firefox Nightly to prevent signing errors.
-- cd $TRAVIS_BUILD_DIR/../
-- wget "https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US" -O firefox.tar.bz2 && tar xvf firefox.tar.bz2
-- cd $TRAVIS_BUILD_DIR
+# Install unbranded Firefox to prevent signing errors.
+- npm run get-unbranded-firefox -- --extract-to ../
 script:
 - export JPM_FIREFOX_BINARY=$TRAVIS_BUILD_DIR/../firefox/firefox-bin
 - npm run-script jshint

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "node ./test/run.js",
     "prepush": "npm run jshint && npm run jscs && npm run documentation",
     "changelog": "conventional-changelog -p angular -u",
-    "changelog-lint": "conventional-changelog-lint --from master"
+    "changelog-lint": "conventional-changelog-lint --from master",
+    "get-unbranded-firefox": "get-firefox -ecb unbranded-release"
   },
   "homepage": "https://github.com/mozilla-jetpack/jpm",
   "repository": {
@@ -74,6 +75,7 @@
     "conventional-changelog-cli": "1.2.0",
     "conventional-changelog-lint": "1.0.0",
     "dive": "0.4.0",
+    "get-firefox": "1.4.0",
     "glob": "5.0.3",
     "husky": "^0.10.1",
     "jscs": "^2.7.0",


### PR DESCRIPTION
Switch to using a release equivalent build for running tests instead of nightly. Fixes #562 for good.