### PR TITLE
test: Update get-firefox to version that doesn't write archive to disk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 - npm install
 before_script:
 # Install unbranded Firefox to prevent signing errors.
-- npm run get-unbranded-firefox -- --extract-to ../
+- npm run get-unbranded-firefox -- --target ../
 script:
 - export JPM_FIREFOX_BINARY=$TRAVIS_BUILD_DIR/../firefox/firefox-bin
 - npm run-script jshint

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "conventional-changelog-cli": "1.2.0",
     "conventional-changelog-lint": "1.0.0",
     "dive": "0.4.0",
-    "get-firefox": "1.4.0",
+    "get-firefox": "1.5.0",
     "glob": "5.0.3",
     "husky": "^0.10.1",
     "jscs": "^2.7.0",


### PR DESCRIPTION
This version of `get-firefox` addresses writing the archive to disk and instead directly unzips it to the target directory.