### PR TITLE
Fix #329: Expose --xpi-path to the command line, so the output directory for the xpi can be set.

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -41,6 +41,11 @@ program
             return path.resolve(dir);
           },
           process.cwd())
+  .option("--xpi-path <path>", "Output directory path for the add-on",
+          // turn into an absolute path
+          function(dir) {
+            return path.resolve(dir);
+          })
   .option("--binary-args <CMDARGS>", "Pass additional arguments into Firefox.")
   .option("--prefs <path>", "Custom set user preferences (path to a json file)")
   .option("--post-url <url>", "A url to post a xpi of your extension")


### PR DESCRIPTION
As discussed in #329 it would be nice to be able to set the output directory for the xpi.

This just exposes the already existing option `xpiPath` to the command line as `--xpi-path`.

There's no default supplied so the existing behavior without `--xpi-path` will be unaffected.