### PR TITLE
feat: Added troubleshooting note about invalid IDs

### DIFF
--- a/lib/sign.js
+++ b/lib/sign.js
@@ -106,7 +106,9 @@ function sign(options, config) {
           "Troubleshooting:\n" +
           "- Are you in the right directory? If not, try --addon-dir\n" +
           "- Are you really in a directory of SDK add-on source? If not, try " +
-             "signing with the --xpi option\n");
+             "signing with the --xpi option\n" +
+          "- Is your manifest ID valid? See " +
+          "https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id\n");
     }
 
     return config.signAddon({


### PR DESCRIPTION
Fixes https://github.com/mozilla-jetpack/jpm/issues/575

Bah. I can't fix this for real because `getID()` is one of those functions that returns null for invalid IDs *or* for missing IDs. There is no easy way to detect this. The best thing we can do is add a troubleshooting note about the error.