### PR TITLE
using `--profile` doesn't re-use prefs, for complex reasons.

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -2,15 +2,41 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
-
+var fs = require("fs");
 var FirefoxProfile = require("firefox-profile");
 var FirefoxProfileFinder = require("firefox-profile/lib/profile_finder");
 var getPrefs = require("./preferences").getPrefs;
 var when = require("when");
 var console = require("./utils").console;
 
+// revised from firefox_profile, b/c node fs module required encoding
+function readExistingUserjs(profile) {
+  var self = profile;
+  var regExp = /user_pref\('(.*)',\s(.*)\)/;
+  var contentLines = fs.readFileSync(self.userPrefs, {encoding: "utf8"}).
+    split("\n");
+  contentLines.forEach(function(line) {
+    var found = line.match(regExp);
+    if (found && found[1]) {
+      self.defaultPreferences[found[1]] = found[2];
+    }
+  });
+}
+
+function setAppPrefs(profile) {
+  // Set default preferences
+  var prefs = getPrefs("firefox");
+  Object.keys(prefs).forEach(function(pref) {
+    profile.setPreference(pref, prefs[pref]);
+  });
+  profile.updatePreferences();
+}
+
 function copyProfile(profile) {
-  return when.resolve(new FirefoxProfile(profile));
+  profile = new FirefoxProfile(profile);
+  readExistingUserjs(profile);
+  setAppPrefs(profile);
+  return when.resolve(profile);
 }
 exports.copyProfile = copyProfile;
 
@@ -24,12 +50,7 @@ exports.reuseProfile = reuseProfile;
 function makeProfile() {
   var profile = new FirefoxProfile();
 
-  // Set default preferences
-  var prefs = getPrefs("firefox");
-  Object.keys(prefs).forEach(function(pref) {
-    profile.setPreference(pref, prefs[pref]);
-  });
-  profile.updatePreferences();
+  setAppPrefs(profile);
 
   return when.resolve(profile);
 }


### PR DESCRIPTION
Claim:
1.  expect --profile (copy or otherwise) to start with same user.js
2.  MAYBE the jpm prefs should override?  I dunno

What happens:
1.  We end up with the `default` set from `firefox-profile` package, which is not what we want.

Why:

- `new FirefoxProfile(aPath)` creates a profile not using the existing prefs.

I am open to ideas about what the 'right' behaviour should be.


Easy fix, once we decide.

(Fwiw, `firefox-profile` 0.4.0, the next in the series, changes the new FirefoxProfile interface and is ALSO buggy / wrong when cloning.  BE WARNED)