### PR TITLE
fix: Fixed bootstrap.js and install.rdf not generating for Firefox >= 50.0a

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -52,12 +52,7 @@ program
   .option("--debug", "Enable the add-on debugger when running the add-on")
   .option("--check-memory",
           "Enable leaked tracker that attempts to report compartments leaked")
-  .option("--profile-memory", "Enable profiling of memory usage")
-  .option(
-    "--retro",
-    "In development flag for transitioning to new style addons; forces the " +
-      "lack of install.rdf/bootstrap.js creation regardless of what engine " +
-      "versions are running");
+  .option("--profile-memory", "Enable profiling of memory usage");
 
 program
   .command("docs")

--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -44,9 +44,6 @@ function validateProgram(program) {
         (option + " set to " + program[option]) :
         (option + " set"));
     }
-    if (option === "forceAOM") {
-      console.warn("`forceAOM` flag set; this feature is experimental.");
-    }
     if (program.overload && (!process.env.JETPACK_ROOT &&
                              typeof program.overload === "boolean")) {
       console.warn(

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -9,8 +9,6 @@ exports.MIN_VERSION = "38.0a1";
 // Set a MAX_VERSION to use in install.rdf - default MAX_VERSION is "*".
 // See this page for supported ranges: https://addons.mozilla.org/en-US/firefox/pages/appversions/
 exports.MAX_VERSION = "*";
-// This isn't implemented, so crank up the AOM_SUPPORT_VERSION
-exports.AOM_SUPPORT_VERSION = "50.0a";
 
 exports.AMO_API_PREFIX = "https://addons.mozilla.org/api/v3";
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,48 +11,7 @@ var tmp = require("tmp");
 var when = require("when");
 var nodefn = require("when/node");
 var DecompressZip = require("decompress-zip");
-var parse = require("mozilla-toolkit-versioning").parse;
-var compare = require("mozilla-version-comparator");
 var xml2js = require("xml2js");
-var AOM_SUPPORT_VERSION = require("./settings").AOM_SUPPORT_VERSION;
-
-/**
- * Takes a `manifest` object and determines whether or not
- * AOM is supported by all platforms that the addon supports.
- *
- * @param {Object} manifest
- * @return {Boolean}
- */
-
-function hasAOMSupport(manifest) {
-  // If no engines specified, assume no AOM support
-  if (!manifest.engines) {
-    return false;
-  }
-  var engines = Object.keys(manifest.engines);
-  var supported = true;
-
-  // If engines field exists, but no engines specified, assume no AOM support
-  if (!engines.length) {
-    return false;
-  }
-
-  Object.keys(manifest.engines).forEach(function(engine) {
-    var parsed = parse(manifest.engines[engine]);
-    // If no minimum engine support specified, unsupported
-    if (!parsed.min) {
-      supported = false;
-      return;
-    }
-
-    // If minimum engine support is less than AOM support, unsupported
-    if (compare(parsed.min, AOM_SUPPORT_VERSION) === -1) {
-      supported = false;
-    }
-  });
-  return supported;
-}
-exports.hasAOMSupport = hasAOMSupport;
 
 /**
  * Exports a `console` object that has several methods

--- a/lib/xpi.js
+++ b/lib/xpi.js
@@ -6,7 +6,6 @@
 var join = require("path").join;
 var getID = require("jetpack-id");
 var validate = require("./validate");
-var hasAOMSupport = require("./utils").hasAOMSupport;
 var utils = require("./xpi/utils");
 var console = require("./utils").console;
 var _ = require("lodash");
@@ -52,13 +51,12 @@ function xpi(manifest, options) {
   var outputPath = options.xpiPath || options.destDir || addonDir;
   var xpiPath = join(outputPath, xpiName);
   var updateRdfPath = join(outputPath, updateRdfName);
-  var useFallbacks = !(options.forceAOM || hasAOMSupport(manifest));
 
   options = _.merge(options, {
     addonDir: addonDir,
     xpiName: xpiName,
     xpiPath: xpiPath,
-    useFallbacks: useFallbacks,
+    useFallbacks: true,
     needsInstallRDF: undefined,
     needsBootstrapJS: undefined,
     bootstrapSrc: require.resolve("jpm-core/data/bootstrap.js")

--- a/lib/xpi/utils.js
+++ b/lib/xpi/utils.js
@@ -66,8 +66,7 @@ function checkNeedsFallbacks(options) {
 }
 exports.checkNeedsFallbacks = checkNeedsFallbacks;
 
-// Creates bootstrap.js/install.rdf -- will be removed once
-// AOM is updated
+// Creates bootstrap.js/install.rdf
 function createFallbacks(options) {
   var bootstrapSrc = options.bootstrapSrc;
 

--- a/test/unit/test.utils.js
+++ b/test/unit/test.utils.js
@@ -8,7 +8,6 @@ var path = require("path");
 var chai = require("chai");
 var expect = chai.expect;
 var utils = require("../../lib/utils");
-var hasAOMSupport = utils.hasAOMSupport;
 
 var simpleAddonPath = path.join(__dirname, "..", "addons", "simple-addon");
 var simpleAddonXPI = path.join(__dirname, "..", "xpis", "@simple-addon.xpi");
@@ -270,35 +269,5 @@ describe("lib/utils", function() {
         });
     });
 
-  });
-
-  describe("hasAOMSupport", function() {
-    it("hasAOMSupport true for valid ranges", function() {
-      [">=51 <=54", ">=50.0a <=52", ">=50", ">=51.0a"].forEach(function(range) {
-        expect(hasAOMSupport({ engines: { "firefox": range } })).to.be.equal(true);
-      });
-    });
-    it("hasAOMSupport false for invalid ranges", function() {
-      [">=28 <=34", ">=30 <=32", ">=26", ">=30.0a", ">=38 <=44"].forEach(function(range) {
-        expect(hasAOMSupport({ engines: { "firefox": range } })).to.be.equal(false);
-      });
-    });
-    it("hasAOMSupport false for unspecified min", function() {
-      ["<26", "<=32", "<40.0a"].forEach(function(range) {
-        expect(hasAOMSupport({ engines: { "firefox": range } })).to.be.equal(false);
-      });
-    });
-    it("hasAOMSupport false for no engines field", function() {
-      expect(hasAOMSupport({})).to.be.equal(false);
-    });
-    it("hasAOMSupport false for unpopulated engines field", function() {
-      expect(hasAOMSupport({ engines: {}})).to.be.equal(false);
-    });
-    it("hasAOMSupport false for one valid and one invalid engine", function() {
-      expect(hasAOMSupport({ engines: {
-        "firefox": ">=40.0a",
-        "fennec": "<31"
-      }})).to.be.equal(false);
-    });
   });
 });


### PR DESCRIPTION
This fixes #590 by removing every trace of that feature. I did not remove the tests since it seems to test unrelated things, like the actual generation of install.rdf and bootstrap.js