### PR TITLE
fix: Add support for proxy configuration

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -101,6 +101,7 @@ program
           "optional XPI to be signed. By default, an XPI will be built " +
           "from your working directory")
   .option("--timeout <milliseconds>", "time to wait for a signing result")
+  .option("--api-proxy <url>", "Optional proxy to use for all API requests")
   .action(function(options) {
     signCmd(program, options);
   });

--- a/bin/jpm
+++ b/bin/jpm
@@ -101,7 +101,8 @@ program
           "optional XPI to be signed. By default, an XPI will be built " +
           "from your working directory")
   .option("--timeout <milliseconds>", "time to wait for a signing result")
-  .option("--api-proxy <url>", "Optional proxy to use for all API requests")
+  .option("--api-proxy <url>", "Optional proxy to use for all API requests." +
+          " Example: https://yourproxy:6000")
   .action(function(options) {
     signCmd(program, options);
   });

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -119,6 +119,7 @@ function sign(options, config) {
       apiUrlPrefix: options.apiUrlPrefix,
       verbose: options.verbose,
       timeout: options.timeout || undefined,
+      apiProxy: options.apiProxy || undefined
     }).then(function(result) {
       if (typeof xpiInfo.cleanUp !== "undefined") {
         logger.debug("cleaning up XPI temp directory");

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -117,9 +117,9 @@ function sign(options, config) {
       apiKey: options.apiKey,
       apiSecret: options.apiSecret,
       apiUrlPrefix: options.apiUrlPrefix,
+      apiProxy: options.apiProxy || undefined,
       verbose: options.verbose,
-      timeout: options.timeout || undefined,
-      apiProxy: options.apiProxy || undefined
+      timeout: options.timeout || undefined
     }).then(function(result) {
       if (typeof xpiInfo.cleanUp !== "undefined") {
         logger.debug("cleaning up XPI temp directory");

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -187,7 +187,7 @@ describe("sign", function() {
     }).catch(done);
   });
 
-    it("passes custom XPI to the signer", function(done) {
+  it("passes custom XPI to the signer", function(done) {
     var mockXpiInfoGetter = new CallableMock({
       returnValue: when.promise(function(resolve) {
         resolve({

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -173,7 +173,21 @@ describe("sign", function() {
     }).catch(done);
   });
 
-  it("passes custom XPI to the signer", function(done) {
+  it("can configure a proxy", function(done) {
+    runSignCmd({
+      cmdOptions: {
+        apiKey: "some-key",
+        apiSecret: "some-secret",
+        apiProxy: "some-proxy",
+      },
+    }).then(function() {
+      expect(signAddonCall.call[0].apiProxy)
+        .to.be.equal("some-proxy");
+      done();
+    }).catch(done);
+  });
+
+    it("passes custom XPI to the signer", function(done) {
     var mockXpiInfoGetter = new CallableMock({
       returnValue: when.promise(function(resolve) {
         resolve({

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -174,7 +174,7 @@ describe("sign", function() {
   });
 
   it("can configure a proxy", function() {
-    runSignCmd({
+    return runSignCmd({
       cmdOptions: {
         apiKey: "some-key",
         apiSecret: "some-secret",

--- a/test/unit/test.sign.js
+++ b/test/unit/test.sign.js
@@ -173,7 +173,7 @@ describe("sign", function() {
     }).catch(done);
   });
 
-  it("can configure a proxy", function(done) {
+  it("can configure a proxy", function() {
     runSignCmd({
       cmdOptions: {
         apiKey: "some-key",
@@ -183,8 +183,7 @@ describe("sign", function() {
     }).then(function() {
       expect(signAddonCall.call[0].apiProxy)
         .to.be.equal("some-proxy");
-      done();
-    }).catch(done);
+    });
   });
 
   it("passes custom XPI to the signer", function(done) {


### PR DESCRIPTION
Allows using a proxy when signing addons.
Since mozilla/sign-addon already supports a proxy configuration, this change will pass on the option to sign-addon

Fixes https://github.com/mozilla-jetpack/jpm/issues/446
