### PR TITLE
fix: Fixed TypeError when running `jpm post`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,6 +34,7 @@ function log(type) {
 }
 
 var jpmConsole = {
+  info: log.bind(null, "info"),
   log: log.bind(null, "info"),
   warn: log.bind(null, "warning"),
   error: log.bind(null, "error"),


### PR DESCRIPTION
Fixes https://github.com/mozilla-jetpack/jpm/issues/596

The pseudo log object did not define an info method and this command never had test coverage for some reason.