### PR TITLE
chore: Don't check readme pre push but check commit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "documentation": "mocha -t 5000 test/documentation",
     "lint": "eslint bin/jpm lib test",
     "test": "node ./test/run.js",
-    "prepush": "npm run lint && npm run documentation",
+    "prepush": "npm run lint",
+    "commitmsg": "npm run changelog-lint",
     "changelog": "conventional-changelog -p angular -u",
     "changelog-lint": "conventional-changelog-lint --from master",
     "get-unbranded-firefox": "get-firefox -ecb unbranded-release"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint bin/jpm lib test",
     "test": "node ./test/run.js",
     "prepush": "npm run lint",
-    "commitmsg": "npm run changelog-lint",
+    "commitmsg": "cat \"$GIT_PARAMS\" | conventional-changelog-lint",
     "changelog": "conventional-changelog -p angular -u",
     "changelog-lint": "conventional-changelog-lint --from master",
     "get-unbranded-firefox": "get-firefox -ecb unbranded-release"
@@ -76,7 +76,7 @@
     "eslint-plugin-dependencies": "1.3.0",
     "get-firefox": "1.5.0",
     "glob": "5.0.3",
-    "husky": "^0.10.1",
+    "husky": "0.11.9",
     "mocha": "2.5.3",
     "release-it": "2.3.1",
     "rimraf": "2.3.2",


### PR DESCRIPTION
This runs the changelog-lint script at the git "commit-msg" hook, like the web-ext setup does. I've also tested it on Windows, where it works, except with GitHub for Windows, which probably doesn't support git hooks, though I suspect push would fail there too.

Further it removes the documentation spellcheck from pre-push. While doing that, I was wondering, if ti was worth adding `--cache` to the pre-push eslint, though I think there's not enough push frequency and it's not that slow to warrant that.

This fixes #594 
