### PR TITLE
Allow package.json to explicitly set em:multiprocessCompatible to false

### DIFF
--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -103,7 +103,8 @@ function createRDF(manifest, needsBootstrapJS) {
   }
 
   if (manifest.permissions && manifest.permissions.multiprocess !== undefined) {
-    jetpackMeta["em:multiprocessCompatible"] = manifest.permissions.multiprocess;
+    var supportsMultiprocess = manifest.permissions.multiprocess;
+    jetpackMeta["em:multiprocessCompatible"] = supportsMultiprocess;
   }
 
   if (manifest.hasEmbeddedWebExtension) {

--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -102,8 +102,8 @@ function createRDF(manifest, needsBootstrapJS) {
     jetpackMeta["em:optionsType"] = 3;
   }
 
-  if (manifest.permissions && manifest.permissions.multiprocess === true) {
-    jetpackMeta["em:multiprocessCompatible"] = true;
+  if (manifest.permissions && manifest.permissions.multiprocess !== undefined) {
+    jetpackMeta["em:multiprocessCompatible"] = manifest.permissions.multiprocess;
   }
 
   if (manifest.hasEmbeddedWebExtension) {

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -203,8 +203,8 @@ describe("lib/rdf", function() {
       expect(getData(xml, "em:multiprocessCompatible")).to.be.equal("true");
 
       xml = parseRDF(RDF.createRDF({ id: "1", permissions: { multiprocess: false } }));
-      expect(nodeExists(xml, "em:multiprocessCompatible")).to.be.equal(false);
-      expect(getData(xml, "em:multiprocessCompatible")).to.be.equal(undefined);
+      expect(nodeExists(xml, "em:multiprocessCompatible")).to.be.equal(true);
+      expect(getData(xml, "em:multiprocessCompatible")).to.be.equal("false");
     });
 
     it("adds `translator` fields for each translator", function() {


### PR DESCRIPTION
Fixes #607  - All unit tests (`npm run unit`) pass: `125 passing (1s)`